### PR TITLE
proper implementation of Dragonbane charm

### DIFF
--- a/src/main/arrays.js
+++ b/src/main/arrays.js
@@ -81,6 +81,8 @@ var labyrinthMiceClues = {
     "Treasure Brawler": 2
 };
 
+var dragons = ["Dragon", "Dragoon", "Ful'Mina", "Thunder Strike", "Thundering Watcher", "Thunderlord", "Violet Stormchild"];
+
 var berglings = ["Incompetent Ice Climber", "Polar Bear", "Snow Slinger", "Snow Soldier", "Iceblock", "Wolfskie", "Snowblind"];
 var brutes = ["Snow Bowler", "Yeti", "Mammoth"];
 var bombSquad = ["Saboteur", "Stickybomber", "Heavy Blaster"];

--- a/src/main/cre.js
+++ b/src/main/cre.js
@@ -412,6 +412,13 @@ function showPop(type) { //type = 2 means don't reset charms
                             calculateTrapSetup(true);
                         }
                     }
+                } else if (charmName === "Dragonbane Charm" && contains(dragons, mouseName)) {
+                    //Dragonbane Charm has 300% power bonus agains dragons
+                    charmBonus += 300;
+                    calculateTrapSetup(true); // not "cre" or else infinite loop
+                    catchRate = calcCR(eff, trapPower, trapLuck, mousePower);
+                    charmBonus -= 300;
+                    calculateTrapSetup(true);
                 }
 
                 var minLuckValue = minLuck(eff, mousePower);
@@ -440,10 +447,8 @@ function showPop(type) { //type = 2 means don't reset charms
                 minLuckOverall = Math.max(minLuckValue, minLuckOverall);
 
                 //Exceptions, modifications to catch rates
-                //Dragonbane Charm
                 if (charmName === "Ultimate Charm") catchRate = 1;
                 else if (locationName === "Sunken City" && charmName === "Ultimate Anchor Charm" && phaseName !== "Docked") catchRate = 1;
-                else if (mouseName === "Dragon" && charmName === "Dragonbane Charm") catchRate *= 2;
                 else if (mouseName === "Bounty Hunter" && charmName === "Sheriff's Badge Charm") catchRate = 1;
                 else if (mouseName === "Zurreal the Eternal" && weaponName !== "Zurreal's Folly") catchRate = 0;
 


### PR DESCRIPTION
Implemented Dragonbane charm as 300% power bonus instead of double catch rate and supports all current dragon mice.

Note: Ful'Mina is written in short form, as I expect there would be a lot of problems handling the full name.