### PR TITLE
Update BWRift population and support paladin's bane buff

### DIFF
--- a/data/pop-bwrift.csv
+++ b/data/pop-bwrift.csv
@@ -177,8 +177,8 @@
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","5.48%","Record Keeper",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","4.41%","Epoch Golem",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","1.13%","Dread Knight",42312
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","0.53%","Record Keeper's Assistant",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","0.53%","Sentient Slime",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","0.53%","Record Keeper's Assistant",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","45.79%","Clockwork Timespinner",47427
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","41.48%","Portal Plunderer",47427
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","5.82%","Record Keeper",47427
@@ -204,25 +204,14 @@
 "Bristle Woods Rift","Entrance","Runic String","-","3.69%","Portal Plunderer",325
 "Bristle Woods Rift","Entrance","Runic String","-","3.08%","Epoch Golem",325
 "Bristle Woods Rift","Entrance","Runic String","-","3.08%","Skeletal Champion",325
-"Bristle Woods Rift","Entrance","Runic String","-","0.62%","Sentient Slime",325
 "Bristle Woods Rift","Entrance","Runic String","-","0.62%","Clockwork Timespinner",325
+"Bristle Woods Rift","Entrance","Runic String","-","0.62%","Sentient Slime",325
 "Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","80.95%","Vigilant Ward",368
 "Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","10.64%","Portal Paladin",368
 "Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","3.92%","Portal Plunderer",368
 "Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","3.36%","Epoch Golem",368
 "Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","0.56%","Sentient Slime",368
 "Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","0.56%","Clockwork Timespinner",368
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","87.63%","Vigilant Ward",325
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","4.12%","Portal Plunderer",325
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","3.44%","Skeletal Champion",325
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","3.44%","Epoch Golem",325
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","0.69%","Clockwork Timespinner",325
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","0.69%","Sentient Slime",325
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","90.60%","Vigilant Ward",368
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","4.39%","Portal Plunderer",368
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","3.76%","Epoch Golem",368
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","0.63%","Clockwork Timespinner",368
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","0.63%","Sentient Slime",368
 "Bristle Woods Rift","Frozen Alcove","Runic String","-","54.79%","Sentient Slime",4344
 "Bristle Woods Rift","Frozen Alcove","Runic String","-","38.59%","Dread Knight",4344
 "Bristle Woods Rift","Frozen Alcove","Runic String","-","6.11%","Portal Paladin",4344
@@ -275,20 +264,20 @@
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","Rift Antiskele","12.31%","Dread Knight",1519
 "Bristle Woods Rift","Furnace Room","Brie String","-","91.90%","Skeletal Champion",328
 "Bristle Woods Rift","Furnace Room","Brie String","-","2.80%","Portal Paladin",328
-"Bristle Woods Rift","Furnace Room","Brie String","-","1.87%","Portal Plunderer",328
 "Bristle Woods Rift","Furnace Room","Brie String","-","1.87%","Clockwork Timespinner",328
+"Bristle Woods Rift","Furnace Room","Brie String","-","1.87%","Portal Plunderer",328
 "Bristle Woods Rift","Furnace Room","Brie String","-","1.56%","Dread Knight",328
 "Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","35.42%","Portal Paladin",419
 "Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","31.25%","Clockwork Timespinner",419
-"Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","16.67%","Dread Knight",419
 "Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","16.67%","Portal Plunderer",419
+"Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","16.67%","Dread Knight",419
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","94.55%","Skeletal Champion",328
-"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.92%","Clockwork Timespinner",328
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.92%","Portal Plunderer",328
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.92%","Clockwork Timespinner",328
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.60%","Dread Knight",328
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","48.39%","Clockwork Timespinner",419
-"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","25.81%","Dread Knight",419
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","25.81%","Portal Plunderer",419
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","25.81%","Dread Knight",419
 "Bristle Woods Rift","Gearworks","Runic String","-","37.44%","Dread Knight",2221
 "Bristle Woods Rift","Gearworks","Runic String","-","25.21%","Chamber Cleaver",2221
 "Bristle Woods Rift","Gearworks","Runic String","-","11.37%","Portal Plunderer",2221
@@ -313,8 +302,8 @@
 "Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.27%","Vigilant Ward",2427
 "Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.27%","Timelost Thaumaturge",2427
 "Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.09%","Shackled Servant",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.05%","Timeslither Pythoness",2427
 "Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.05%","Harbinger of Death",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.05%","Timeslither Pythoness",2427
 "Bristle Woods Rift","Gearworks","Ancient String","-","38.49%","Dread Knight",564
 "Bristle Woods Rift","Gearworks","Ancient String","-","13.13%","Portal Plunderer",564
 "Bristle Woods Rift","Gearworks","Ancient String","-","9.17%","Record Keeper's Assistant",564
@@ -455,74 +444,25 @@
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","10.91%","Dread Knight",734
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","6.80%","Clockwork Timespinner",734
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","4.11%","Portal Plunderer",734
-"Bristle Woods Rift","Guard Barracks","Runic String","-","65.46%","Portal Paladin",6785
-"Bristle Woods Rift","Guard Barracks","Runic String","-","17.98%","Dread Knight",6785
-"Bristle Woods Rift","Guard Barracks","Runic String","-","13.45%","Epoch Golem",6785
-"Bristle Woods Rift","Guard Barracks","Runic String","-","2.05%","Clockwork Timespinner",6785
-"Bristle Woods Rift","Guard Barracks","Runic String","-","1.06%","Sentient Slime",6785
-"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","65.45%","Portal Paladin",6969
-"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","18.05%","Dread Knight",6969
-"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","13.45%","Epoch Golem",6969
-"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","2.01%","Clockwork Timespinner",6969
-"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","1.03%","Sentient Slime",6969
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","57.48%","Portal Paladin",2029
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","15.56%","Dread Knight",2029
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","11.55%","Sentient Slime",2029
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","9.22%","Epoch Golem",2029
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","6.19%","Clockwork Timespinner",2029
-"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","57.16%","Portal Paladin",2084
-"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","15.77%","Dread Knight",2084
-"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","11.58%","Sentient Slime",2084
-"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","9.36%","Epoch Golem",2084
-"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","6.13%","Clockwork Timespinner",2084
-"Bristle Woods Rift","Guard Barracks","Magical String","-","45.06%","Portal Paladin",1864
-"Bristle Woods Rift","Guard Barracks","Magical String","-","18.03%","Sentient Slime",1864
-"Bristle Woods Rift","Guard Barracks","Magical String","-","14.38%","Clockwork Timespinner",1864
-"Bristle Woods Rift","Guard Barracks","Magical String","-","11.96%","Epoch Golem",1864
-"Bristle Woods Rift","Guard Barracks","Magical String","-","10.57%","Dread Knight",1864
-"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","44.94%","Portal Paladin",1896
-"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","18.04%","Sentient Slime",1896
-"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","14.50%","Clockwork Timespinner",1896
-"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","11.97%","Epoch Golem",1896
-"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","10.55%","Dread Knight",1896
-"Bristle Woods Rift","Guard Barracks","Brie String","-","41.27%","Portal Paladin",2154
-"Bristle Woods Rift","Guard Barracks","Brie String","-","26.61%","Clockwork Timespinner",2154
-"Bristle Woods Rift","Guard Barracks","Brie String","-","23.11%","Sentient Slime",2154
-"Bristle Woods Rift","Guard Barracks","Brie String","-","9.01%","Dread Knight",2154
-"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","41.05%","Portal Paladin",2309
-"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","26.69%","Clockwork Timespinner",2309
-"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","23.07%","Sentient Slime",2309
-"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","9.19%","Dread Knight",2309
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","52.05%","Dread Knight",6785
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","38.93%","Epoch Golem",6785
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","5.94%","Clockwork Timespinner",6785
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","3.08%","Sentient Slime",6785
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","52.25%","Dread Knight",6969
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","38.94%","Epoch Golem",6969
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","5.82%","Clockwork Timespinner",6969
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","3.00%","Sentient Slime",6969
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","36.60%","Dread Knight",2029
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","27.16%","Sentient Slime",2029
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","21.68%","Epoch Golem",2029
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","14.57%","Clockwork Timespinner",2029
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","36.82%","Dread Knight",2084
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","27.03%","Sentient Slime",2084
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","21.85%","Epoch Golem",2084
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","14.30%","Clockwork Timespinner",2084
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","32.81%","Sentient Slime",1864
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","26.17%","Clockwork Timespinner",1864
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","21.78%","Epoch Golem",1864
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","19.24%","Dread Knight",1864
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","32.76%","Sentient Slime",1896
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","26.34%","Clockwork Timespinner",1896
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","21.74%","Epoch Golem",1896
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","19.16%","Dread Knight",1896
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","45.31%","Clockwork Timespinner",2154
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","39.35%","Sentient Slime",2154
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","15.34%","Dread Knight",2154
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","Rift Antiskele","45.27%","Clockwork Timespinner",2309
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","Rift Antiskele","39.14%","Sentient Slime",2309
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","Rift Antiskele","15.58%","Dread Knight",2309
+"Bristle Woods Rift","Guard Barracks","Runic String","-","65.45%","Portal Paladin",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","-","18.05%","Dread Knight",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","-","13.45%","Epoch Golem",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","-","2.01%","Clockwork Timespinner",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","-","1.03%","Sentient Slime",6969
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","57.16%","Portal Paladin",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","15.77%","Dread Knight",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","11.58%","Sentient Slime",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","9.36%","Epoch Golem",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","6.13%","Clockwork Timespinner",2084
+"Bristle Woods Rift","Guard Barracks","Magical String","-","44.94%","Portal Paladin",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","-","18.04%","Sentient Slime",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","-","14.50%","Clockwork Timespinner",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","-","11.97%","Epoch Golem",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","-","10.55%","Dread Knight",1896
+"Bristle Woods Rift","Guard Barracks","Brie String","-","41.05%","Portal Paladin",2309
+"Bristle Woods Rift","Guard Barracks","Brie String","-","26.69%","Clockwork Timespinner",2309
+"Bristle Woods Rift","Guard Barracks","Brie String","-","23.07%","Sentient Slime",2309
+"Bristle Woods Rift","Guard Barracks","Brie String","-","9.19%","Dread Knight",2309
 "Bristle Woods Rift","Hidden Treasury","Runic String","-","27.20%","Timeless Lich",842
 "Bristle Woods Rift","Hidden Treasury","Runic String","-","25.89%","Timeslither Pythoness",842
 "Bristle Woods Rift","Hidden Treasury","Runic String","-","11.88%","Portal Plunderer",842
@@ -586,8 +526,8 @@
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","10.21%","Timeless Lich",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","8.72%","Epoch Golem",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","6.15%","Carrion Medium",1874
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","5.03%","Shackled Servant",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","5.03%","Skeletal Champion",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","5.03%","Shackled Servant",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","4.55%","Portal Paladin",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","2.14%","Harbinger of Death",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","38.19%","Portal Plunderer",2237
@@ -667,102 +607,62 @@
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","6.89%","Carrion Medium",2237
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","5.22%","Shackled Servant",2237
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","2.41%","Harbinger of Death",2237
-"Bristle Woods Rift","Ingress","Runic String","-","24.83%","Sentient Slime",2365
-"Bristle Woods Rift","Ingress","Runic String","-","24.67%","Clockwork Timespinner",2365
-"Bristle Woods Rift","Ingress","Runic String","-","23.57%","Dread Knight",2365
-"Bristle Woods Rift","Ingress","Runic String","-","14.30%","Vigilant Ward",2365
-"Bristle Woods Rift","Ingress","Runic String","-","11.31%","Shackled Servant",2365
-"Bristle Woods Rift","Ingress","Runic String","-","1.31%","Harbinger of Death",2365
-"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","25.04%","Clockwork Timespinner",2453
-"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","24.59%","Sentient Slime",2453
-"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","23.28%","Dread Knight",2453
-"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","14.43%","Vigilant Ward",2453
-"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","11.41%","Shackled Servant",2453
-"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","1.26%","Harbinger of Death",2453
-"Bristle Woods Rift","Ingress","Ancient String","-","26.92%","Clockwork Timespinner",761
-"Bristle Woods Rift","Ingress","Ancient String","-","20.28%","Sentient Slime",761
-"Bristle Woods Rift","Ingress","Ancient String","-","19.93%","Dread Knight",761
-"Bristle Woods Rift","Ingress","Ancient String","-","16.08%","Shackled Servant",761
-"Bristle Woods Rift","Ingress","Ancient String","-","15.03%","Vigilant Ward",761
-"Bristle Woods Rift","Ingress","Ancient String","-","1.75%","Harbinger of Death",761
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","26.48%","Clockwork Timespinner",862
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","22.07%","Sentient Slime",862
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","19.33%","Dread Knight",862
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","15.98%","Shackled Servant",862
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","14.61%","Vigilant Ward",862
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","1.52%","Harbinger of Death",862
-"Bristle Woods Rift","Ingress","Magical String","-","31.82%","Sentient Slime",431
-"Bristle Woods Rift","Ingress","Magical String","-","31.06%","Clockwork Timespinner",431
-"Bristle Woods Rift","Ingress","Magical String","-","15.53%","Shackled Servant",431
-"Bristle Woods Rift","Ingress","Magical String","-","14.02%","Vigilant Ward",431
-"Bristle Woods Rift","Ingress","Magical String","-","5.30%","Dread Knight",431
-"Bristle Woods Rift","Ingress","Magical String","-","2.27%","Harbinger of Death",431
-"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","31.70%","Sentient Slime",432
-"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","30.94%","Clockwork Timespinner",432
-"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","15.47%","Shackled Servant",432
-"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","14.34%","Vigilant Ward",432
-"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","5.28%","Dread Knight",432
-"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","2.26%","Harbinger of Death",432
-"Bristle Woods Rift","Ingress","Brie String","-","39.78%","Sentient Slime",992
-"Bristle Woods Rift","Ingress","Brie String","-","30.41%","Clockwork Timespinner",992
-"Bristle Woods Rift","Ingress","Brie String","-","13.67%","Vigilant Ward",992
-"Bristle Woods Rift","Ingress","Brie String","-","9.52%","Shackled Servant",992
-"Bristle Woods Rift","Ingress","Brie String","-","4.30%","Dread Knight",992
-"Bristle Woods Rift","Ingress","Brie String","-","2.30%","Harbinger of Death",992
-"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","39.66%","Sentient Slime",1061
-"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","31.30%","Clockwork Timespinner",1061
-"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","13.31%","Vigilant Ward",1061
-"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","9.35%","Shackled Servant",1061
-"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","4.25%","Dread Knight",1061
-"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","2.12%","Harbinger of Death",1061
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","24.83%","Sentient Slime",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","24.67%","Clockwork Timespinner",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","23.57%","Dread Knight",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","14.30%","Vigilant Ward",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","11.31%","Shackled Servant",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","1.31%","Harbinger of Death",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","25.04%","Clockwork Timespinner",2453
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","24.59%","Sentient Slime",2453
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","23.28%","Dread Knight",2453
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","14.43%","Vigilant Ward",2453
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","11.41%","Shackled Servant",2453
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","1.26%","Harbinger of Death",2453
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","26.92%","Clockwork Timespinner",761
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","20.28%","Sentient Slime",761
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","19.93%","Dread Knight",761
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","16.08%","Shackled Servant",761
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","15.03%","Vigilant Ward",761
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","1.75%","Harbinger of Death",761
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","26.48%","Clockwork Timespinner",862
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","22.07%","Sentient Slime",862
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","19.33%","Dread Knight",862
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","15.98%","Shackled Servant",862
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","14.61%","Vigilant Ward",862
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","1.52%","Harbinger of Death",862
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","31.82%","Sentient Slime",431
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","31.06%","Clockwork Timespinner",431
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","15.53%","Shackled Servant",431
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","14.02%","Vigilant Ward",431
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","5.30%","Dread Knight",431
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","2.27%","Harbinger of Death",431
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","31.70%","Sentient Slime",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","30.94%","Clockwork Timespinner",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","15.47%","Shackled Servant",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","14.34%","Vigilant Ward",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","5.28%","Dread Knight",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","2.26%","Harbinger of Death",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","39.78%","Sentient Slime",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","30.41%","Clockwork Timespinner",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","13.67%","Vigilant Ward",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","9.52%","Shackled Servant",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","4.30%","Dread Knight",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","2.30%","Harbinger of Death",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","39.66%","Sentient Slime",1061
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","31.30%","Clockwork Timespinner",1061
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","13.31%","Vigilant Ward",1061
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","9.35%","Shackled Servant",1061
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","4.25%","Dread Knight",1061
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","2.12%","Harbinger of Death",1061
+"Bristle Woods Rift","Ingress","Runic String","-","20.30%","Clockwork Timespinner",2453
+"Bristle Woods Rift","Ingress","Runic String","-","19.93%","Sentient Slime",2453
+"Bristle Woods Rift","Ingress","Runic String","-","18.92%","Portal Pursuer",2453
+"Bristle Woods Rift","Ingress","Runic String","-","18.87%","Dread Knight",2453
+"Bristle Woods Rift","Ingress","Runic String","-","11.70%","Vigilant Ward",2453
+"Bristle Woods Rift","Ingress","Runic String","-","9.25%","Shackled Servant",2453
+"Bristle Woods Rift","Ingress","Runic String","-","1.02%","Harbinger of Death",2453
+"Bristle Woods Rift","Ingress","Ancient String","-","23.78%","Portal Pursuer",862
+"Bristle Woods Rift","Ingress","Ancient String","-","20.19%","Clockwork Timespinner",862
+"Bristle Woods Rift","Ingress","Ancient String","-","16.82%","Sentient Slime",862
+"Bristle Woods Rift","Ingress","Ancient String","-","14.73%","Dread Knight",862
+"Bristle Woods Rift","Ingress","Ancient String","-","12.18%","Shackled Servant",862
+"Bristle Woods Rift","Ingress","Ancient String","-","11.14%","Vigilant Ward",862
+"Bristle Woods Rift","Ingress","Ancient String","-","1.16%","Harbinger of Death",862
+"Bristle Woods Rift","Ingress","Magical String","-","38.66%","Portal Pursuer",432
+"Bristle Woods Rift","Ingress","Magical String","-","19.44%","Sentient Slime",432
+"Bristle Woods Rift","Ingress","Magical String","-","18.98%","Clockwork Timespinner",432
+"Bristle Woods Rift","Ingress","Magical String","-","9.49%","Shackled Servant",432
+"Bristle Woods Rift","Ingress","Magical String","-","8.80%","Vigilant Ward",432
+"Bristle Woods Rift","Ingress","Magical String","-","3.24%","Dread Knight",432
+"Bristle Woods Rift","Ingress","Magical String","-","1.39%","Harbinger of Death",432
+"Bristle Woods Rift","Ingress","Brie String","-","33.46%","Portal Pursuer",1061
+"Bristle Woods Rift","Ingress","Brie String","-","26.39%","Sentient Slime",1061
+"Bristle Woods Rift","Ingress","Brie String","-","20.83%","Clockwork Timespinner",1061
+"Bristle Woods Rift","Ingress","Brie String","-","8.86%","Vigilant Ward",1061
+"Bristle Woods Rift","Ingress","Brie String","-","6.22%","Shackled Servant",1061
+"Bristle Woods Rift","Ingress","Brie String","-","2.83%","Dread Knight",1061
+"Bristle Woods Rift","Ingress","Brie String","-","1.41%","Harbinger of Death",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","20.30%","Clockwork Timespinner",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","19.93%","Sentient Slime",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","18.92%","Portal Pursuer",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","18.87%","Dread Knight",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","11.70%","Vigilant Ward",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","9.25%","Shackled Servant",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","1.02%","Harbinger of Death",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","23.78%","Portal Pursuer",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","20.19%","Clockwork Timespinner",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","16.82%","Sentient Slime",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","14.73%","Dread Knight",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","12.18%","Shackled Servant",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","11.14%","Vigilant Ward",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","1.16%","Harbinger of Death",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","38.66%","Portal Pursuer",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","19.44%","Sentient Slime",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","18.98%","Clockwork Timespinner",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","9.49%","Shackled Servant",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","8.80%","Vigilant Ward",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","3.24%","Dread Knight",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","1.39%","Harbinger of Death",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","33.46%","Portal Pursuer",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","26.39%","Sentient Slime",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","20.83%","Clockwork Timespinner",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","8.86%","Vigilant Ward",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","6.22%","Shackled Servant",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","2.83%","Dread Knight",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","1.41%","Harbinger of Death",1061
 "Bristle Woods Rift","Lucky Tower","Runic String","-","23.31%","Epoch Golem",1052
 "Bristle Woods Rift","Lucky Tower","Runic String","-","15.60%","Portal Plunderer",1052
 "Bristle Woods Rift","Lucky Tower","Runic String","-","13.32%","Clockwork Timespinner",1052
@@ -907,14 +807,18 @@
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.28%","Sentient Slime",3109
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","6.15%","Epoch Golem",3109
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","1.78%","Harbinger of Death",3109
-"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","94.12%","Skeletal Champion",405
-"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","5.88%","Record Keeper's Assistant",405
-"Bristle Woods Rift","Pursuer Mousoleum","Brie String","Rift Antiskele","93.18%","Record Keeper's Assistant",525
-"Bristle Woods Rift","Pursuer Mousoleum","Brie String","Rift Antiskele","6.82%","Record Keeper",525
-"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","-","94.12%","Skeletal Champion",405
-"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","-","5.88%","Record Keeper's Assistant",405
-"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","93.18%","Record Keeper's Assistant",525
-"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","6.82%","Record Keeper",525
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","82.96%","Skeletal Champion",405
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","11.85%","Portal Pursuer",405
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","5.19%","Record Keeper's Assistant",405
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","Rift Antiskele","69.01%","Portal Pursuer",525
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","Rift Antiskele","28.87%","Record Keeper's Assistant",525
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","Rift Antiskele","2.11%","Record Keeper",525
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","-","82.96%","Skeletal Champion",405
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","-","11.85%","Portal Pursuer",405
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","-","5.19%","Record Keeper's Assistant",405
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","69.01%","Portal Pursuer",525
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","28.87%","Record Keeper's Assistant",525
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","2.11%","Record Keeper",525
 "Bristle Woods Rift","Runic Laboratory","Runic String","-","29.54%","Timelost Thaumaturge",4637
 "Bristle Woods Rift","Runic Laboratory","Runic String","-","15.86%","Shackled Servant",4637
 "Bristle Woods Rift","Runic Laboratory","Runic String","-","15.73%","Chamber Cleaver",4637
@@ -1055,34 +959,6 @@
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","19.38%","Vigilant Ward",172
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","4.38%","Shackled Servant",172
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","3.75%","Harbinger of Death",172
-"Bristle Woods Rift","Security","Runic String","-","91.70%","Skeletal Champion",255
-"Bristle Woods Rift","Security","Runic String","-","7.11%","Timelost Thaumaturge",255
-"Bristle Woods Rift","Security","Runic String","-","0.79%","Shackled Servant",255
-"Bristle Woods Rift","Security","Runic String","-","0.40%","Vigilant Ward",255
-"Bristle Woods Rift","Security","Runic String","Rift Antiskele","77.42%","Timelost Thaumaturge",269
-"Bristle Woods Rift","Security","Runic String","Rift Antiskele","19.35%","Shackled Servant",269
-"Bristle Woods Rift","Security","Runic String","Rift Antiskele","3.23%","Vigilant Ward",269
-"Bristle Woods Rift","Security","Ancient String","-","91.06%","Skeletal Champion",179
-"Bristle Woods Rift","Security","Ancient String","-","6.15%","Timelost Thaumaturge",179
-"Bristle Woods Rift","Security","Ancient String","-","1.68%","Shackled Servant",179
-"Bristle Woods Rift","Security","Ancient String","-","1.12%","Vigilant Ward",179
-"Bristle Woods Rift","Security","Ancient String","Rift Antiskele","62.07%","Timelost Thaumaturge",208
-"Bristle Woods Rift","Security","Ancient String","Rift Antiskele","24.14%","Shackled Servant",208
-"Bristle Woods Rift","Security","Ancient String","Rift Antiskele","13.79%","Vigilant Ward",208
-"Bristle Woods Rift","Security","Magical String","-","91.67%","Skeletal Champion",120
-"Bristle Woods Rift","Security","Magical String","-","5.83%","Timelost Thaumaturge",120
-"Bristle Woods Rift","Security","Magical String","-","1.67%","Vigilant Ward",120
-"Bristle Woods Rift","Security","Magical String","-","0.83%","Shackled Servant",120
-"Bristle Woods Rift","Security","Magical String","Rift Antiskele","76.47%","Timelost Thaumaturge",144
-"Bristle Woods Rift","Security","Magical String","Rift Antiskele","17.65%","Vigilant Ward",144
-"Bristle Woods Rift","Security","Magical String","Rift Antiskele","5.88%","Shackled Servant",144
-"Bristle Woods Rift","Security","Brie String","-","90.58%","Skeletal Champion",913
-"Bristle Woods Rift","Security","Brie String","-","4.21%","Vigilant Ward",913
-"Bristle Woods Rift","Security","Brie String","-","3.33%","Timelost Thaumaturge",913
-"Bristle Woods Rift","Security","Brie String","-","1.88%","Shackled Servant",913
-"Bristle Woods Rift","Security","Brie String","Rift Antiskele","41.33%","Timelost Thaumaturge",1170
-"Bristle Woods Rift","Security","Brie String","Rift Antiskele","37.76%","Vigilant Ward",1170
-"Bristle Woods Rift","Security","Brie String","Rift Antiskele","20.92%","Shackled Servant",1170
 "Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","91.70%","Skeletal Champion",255
 "Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","7.11%","Timelost Thaumaturge",255
 "Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","0.79%","Shackled Servant",255

--- a/data/pop-bwrift.csv
+++ b/data/pop-bwrift.csv
@@ -1,6 +1,9 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
 "Bristle Woods Rift","Acolyte","Runic String","-","23.90%","Skeletal Champion",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","23.69%","Dread Knight",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","9.21%","Vigilant Ward",50105
 "Bristle Woods Rift","Acolyte","Runic String","-","8.05%","Absolute Acolyte",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","7.74%","Portal Paladin",50105
 "Bristle Woods Rift","Acolyte","Runic String","-","6.38%","Timelost Thaumaturge",50105
 "Bristle Woods Rift","Acolyte","Runic String","-","5.47%","Timeslither Pythoness",50105
 "Bristle Woods Rift","Acolyte","Runic String","-","5.36%","Shackled Servant",50105
@@ -8,51 +11,49 @@
 "Bristle Woods Rift","Acolyte","Runic String","-","3.66%","Carrion Medium",50105
 "Bristle Woods Rift","Acolyte","Runic String","-","2.32%","Timeless Lich",50105
 "Bristle Woods Rift","Acolyte","Runic String","-","0.49%","Chronomaster",50105
-"Bristle Woods Rift","Acolyte","Runic String","-","7.74%","Portal Paladin",50105
-"Bristle Woods Rift","Acolyte","Runic String","-","9.21%","Vigilant Ward",50105
-"Bristle Woods Rift","Acolyte","Runic String","-","23.69%","Dread Knight",50105
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","8.43%","Timelost Thaumaturge",55157
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","7.19%","Timeslither Pythoness",55157
 "Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","31.12%","Dread Knight",55157
 "Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","12.15%","Vigilant Ward",55157
 "Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","10.50%","Absolute Acolyte",55157
 "Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","10.08%","Portal Paladin",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","8.43%","Timelost Thaumaturge",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","7.19%","Timeslither Pythoness",55157
 "Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","7.14%","Shackled Servant",55157
 "Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","4.89%","Harbinger of Death",55157
 "Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","4.84%","Carrion Medium",55157
 "Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","3.02%","Timeless Lich",55157
 "Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","0.64%","Chronomaster",55157
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","6.92%","Timelost Thaumaturge",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","25.91%","Skeletal Champion",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","25.68%","Dread Knight",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","9.98%","Vigilant Ward",50105
 "Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","8.72%","Absolute Acolyte",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","6.92%","Timelost Thaumaturge",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","5.93%","Timeslither Pythoness",50105
 "Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","5.81%","Shackled Servant",50105
 "Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","4.03%","Harbinger of Death",50105
 "Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","3.97%","Carrion Medium",50105
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","9.98%","Vigilant Ward",50105
 "Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","2.52%","Timeless Lich",50105
 "Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","0.53%","Chronomaster",50105
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","25.68%","Dread Knight",50105
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","25.91%","Skeletal Champion",50105
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","5.93%","Timeslither Pythoness",50105
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","5.43%","Harbinger of Death",55157
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","7.94%","Shackled Servant",55157
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","8.00%","Timeslither Pythoness",55157
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","9.38%","Timelost Thaumaturge",55157
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","11.68%","Absolute Acolyte",55157
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","13.51%","Vigilant Ward",55157
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","3.36%","Timeless Lich",55157
 "Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","34.60%","Dread Knight",55157
-"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","0.71%","Chronomaster",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","13.51%","Vigilant Ward",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","11.68%","Absolute Acolyte",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","9.38%","Timelost Thaumaturge",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","8.00%","Timeslither Pythoness",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","7.94%","Shackled Servant",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","5.43%","Harbinger of Death",55157
 "Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","5.39%","Carrion Medium",55157
-"Bristle Woods Rift","Ancient Lab","Runic String","-","0.83%","Record Keeper's Assistant",2182
-"Bristle Woods Rift","Ancient Lab","Runic String","-","0.69%","Sentient Slime",2182
-"Bristle Woods Rift","Ancient Lab","Runic String","-","14.04%","Portal Plunderer",2182
-"Bristle Woods Rift","Ancient Lab","Runic String","-","5.32%","Skeletal Champion",2182
-"Bristle Woods Rift","Ancient Lab","Runic String","-","24.55%","Chamber Cleaver",2182
-"Bristle Woods Rift","Ancient Lab","Runic String","-","13.13%","Dread Knight",2182
-"Bristle Woods Rift","Ancient Lab","Runic String","-","3.44%","Portal Paladin",2182
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","3.36%","Timeless Lich",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","0.71%","Chronomaster",55157
 "Bristle Woods Rift","Ancient Lab","Runic String","-","34.74%","Epoch Golem",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","24.55%","Chamber Cleaver",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","14.04%","Portal Plunderer",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","13.13%","Dread Knight",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","5.32%","Skeletal Champion",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","3.44%","Portal Paladin",2182
 "Bristle Woods Rift","Ancient Lab","Runic String","-","2.16%","Clockwork Timespinner",2182
 "Bristle Woods Rift","Ancient Lab","Runic String","-","1.10%","Record Keeper",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","0.83%","Record Keeper's Assistant",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","0.69%","Sentient Slime",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","37.10%","Epoch Golem",2338
 "Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","25.67%","Chamber Cleaver",2338
 "Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","14.91%","Portal Plunderer",2338
 "Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","13.87%","Dread Knight",2338
@@ -61,8 +62,6 @@
 "Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","1.08%","Record Keeper",2338
 "Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","0.81%","Record Keeper's Assistant",2338
 "Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","0.68%","Sentient Slime",2338
-"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","37.10%","Epoch Golem",2338
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","1.13%","Sentient Slime",1603
 "Bristle Woods Rift","Ancient Lab","Ancient String","-","44.05%","Epoch Golem",1603
 "Bristle Woods Rift","Ancient Lab","Ancient String","-","22.31%","Portal Plunderer",1603
 "Bristle Woods Rift","Ancient Lab","Ancient String","-","9.40%","Dread Knight",1603
@@ -71,71 +70,71 @@
 "Bristle Woods Rift","Ancient Lab","Ancient String","-","5.14%","Record Keeper",1603
 "Bristle Woods Rift","Ancient Lab","Ancient String","-","4.14%","Clockwork Timespinner",1603
 "Bristle Woods Rift","Ancient Lab","Ancient String","-","2.26%","Record Keeper's Assistant",1603
-"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","5.58%","Record Keeper",1750
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","1.13%","Sentient Slime",1603
 "Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","46.76%","Epoch Golem",1750
 "Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","23.83%","Portal Plunderer",1750
 "Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","9.82%","Dread Knight",1750
 "Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","6.00%","Portal Paladin",1750
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","5.58%","Record Keeper",1750
 "Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","4.49%","Clockwork Timespinner",1750
-"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","1.15%","Sentient Slime",1750
 "Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","2.37%","Record Keeper's Assistant",1750
-"Bristle Woods Rift","Ancient Lab","Magical String","-","5.17%","Record Keeper's Assistant",3871
-"Bristle Woods Rift","Ancient Lab","Magical String","-","5.58%","Portal Paladin",3871
-"Bristle Woods Rift","Ancient Lab","Magical String","-","13.25%","Clockwork Timespinner",3871
-"Bristle Woods Rift","Ancient Lab","Magical String","-","4.96%","Sentient Slime",3871
-"Bristle Woods Rift","Ancient Lab","Magical String","-","21.21%","Portal Plunderer",3871
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","1.15%","Sentient Slime",1750
 "Bristle Woods Rift","Ancient Lab","Magical String","-","40.09%","Epoch Golem",3871
-"Bristle Woods Rift","Ancient Lab","Magical String","-","4.86%","Skeletal Champion",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","21.21%","Portal Plunderer",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","13.25%","Clockwork Timespinner",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","5.58%","Portal Paladin",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","5.17%","Record Keeper's Assistant",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","4.96%","Sentient Slime",3871
 "Bristle Woods Rift","Ancient Lab","Magical String","-","4.88%","Record Keeper",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","4.86%","Skeletal Champion",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","42.02%","Epoch Golem",4179
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","22.37%","Portal Plunderer",4179
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","13.97%","Clockwork Timespinner",4179
 "Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","5.98%","Portal Paladin",4179
 "Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","5.38%","Record Keeper's Assistant",4179
 "Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","5.15%","Sentient Slime",4179
 "Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","5.13%","Record Keeper",4179
-"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","22.37%","Portal Plunderer",4179
-"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","42.02%","Epoch Golem",4179
-"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","13.97%","Clockwork Timespinner",4179
 "Bristle Woods Rift","Ancient Lab","Brie String","-","40.95%","Clockwork Timespinner",42312
 "Bristle Woods Rift","Ancient Lab","Brie String","-","37.23%","Portal Plunderer",42312
 "Bristle Woods Rift","Ancient Lab","Brie String","-","5.37%","Skeletal Champion",42312
-"Bristle Woods Rift","Ancient Lab","Brie String","-","1.07%","Dread Knight",42312
 "Bristle Woods Rift","Ancient Lab","Brie String","-","5.21%","Record Keeper",42312
 "Bristle Woods Rift","Ancient Lab","Brie String","-","4.97%","Portal Paladin",42312
 "Bristle Woods Rift","Ancient Lab","Brie String","-","4.19%","Epoch Golem",42312
-"Bristle Woods Rift","Ancient Lab","Brie String","-","0.50%","Record Keeper's Assistant",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","-","1.07%","Dread Knight",42312
 "Bristle Woods Rift","Ancient Lab","Brie String","-","0.51%","Sentient Slime",42312
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","1.09%","Dread Knight",47427
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","4.41%","Epoch Golem",47427
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","5.30%","Portal Paladin",47427
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","5.51%","Record Keeper",47427
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","39.28%","Portal Plunderer",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","-","0.50%","Record Keeper's Assistant",42312
 "Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","43.36%","Clockwork Timespinner",47427
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","0.52%","Record Keeper's Assistant",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","39.28%","Portal Plunderer",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","5.51%","Record Keeper",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","5.30%","Portal Paladin",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","4.41%","Epoch Golem",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","1.09%","Dread Knight",47427
 "Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","0.53%","Sentient Slime",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","0.52%","Record Keeper's Assistant",47427
 "Bristle Woods Rift","Ancient Lab","Swiss String","-","26.37%","Portal Plunderer",2155
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","8.99%","Skeletal Champion",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","26.14%","Clockwork Timespinner",2155
 "Bristle Woods Rift","Ancient Lab","Swiss String","-","16.64%","Record Keeper",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","8.99%","Skeletal Champion",2155
 "Bristle Woods Rift","Ancient Lab","Swiss String","-","8.06%","Record Keeper's Assistant",2155
 "Bristle Woods Rift","Ancient Lab","Swiss String","-","6.29%","Portal Paladin",2155
 "Bristle Woods Rift","Ancient Lab","Swiss String","-","5.68%","Sentient Slime",2155
 "Bristle Woods Rift","Ancient Lab","Swiss String","-","1.82%","Dread Knight",2155
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","26.14%","Clockwork Timespinner",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","28.84%","Clockwork Timespinner",2302
 "Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","28.45%","Portal Plunderer",2302
 "Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","18.76%","Record Keeper",2302
 "Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","9.07%","Record Keeper's Assistant",2302
 "Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","6.67%","Portal Paladin",2302
 "Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","6.24%","Sentient Slime",2302
 "Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","1.97%","Dread Knight",2302
-"Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","28.84%","Clockwork Timespinner",2302
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","0.86%","Record Keeper's Assistant",2182
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","13.59%","Dread Knight",2182
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","0.71%","Sentient Slime",2182
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","14.54%","Portal Plunderer",2182
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","5.51%","Skeletal Champion",2182
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","35.98%","Epoch Golem",2182
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","2.23%","Clockwork Timespinner",2182
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","25.43%","Chamber Cleaver",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","14.54%","Portal Plunderer",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","13.59%","Dread Knight",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","5.51%","Skeletal Champion",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","2.23%","Clockwork Timespinner",2182
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","1.14%","Record Keeper",2182
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","0.70%","Sentient Slime",2338
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","0.86%","Record Keeper's Assistant",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","0.71%","Sentient Slime",2182
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","38.49%","Epoch Golem",2338
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","26.63%","Chamber Cleaver",2338
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","15.47%","Portal Plunderer",2338
@@ -143,117 +142,118 @@
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","2.34%","Clockwork Timespinner",2338
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","1.13%","Record Keeper",2338
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","0.84%","Record Keeper's Assistant",2338
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","6.06%","Skeletal Champion",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","0.70%","Sentient Slime",2338
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","46.80%","Epoch Golem",1603
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","23.70%","Portal Plunderer",1603
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","1.20%","Sentient Slime",1603
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","2.40%","Record Keeper's Assistant",1603
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","4.39%","Clockwork Timespinner",1603
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","5.46%","Record Keeper",1603
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","9.99%","Dread Knight",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","6.06%","Skeletal Champion",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","5.46%","Record Keeper",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","4.39%","Clockwork Timespinner",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","2.40%","Record Keeper's Assistant",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","1.20%","Sentient Slime",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","49.74%","Epoch Golem",1750
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","25.35%","Portal Plunderer",1750
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","10.45%","Dread Knight",1750
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","5.94%","Record Keeper",1750
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","4.77%","Clockwork Timespinner",1750
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","2.52%","Record Keeper's Assistant",1750
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","1.23%","Sentient Slime",1750
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","49.74%","Epoch Golem",1750
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","25.35%","Portal Plunderer",1750
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","10.45%","Dread Knight",1750
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","5.14%","Skeletal Champion",3871
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","42.46%","Epoch Golem",3871
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","22.46%","Portal Plunderer",3871
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","14.04%","Clockwork Timespinner",3871
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","5.47%","Record Keeper's Assistant",3871
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","5.25%","Sentient Slime",3871
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","5.17%","Record Keeper",3871
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","5.14%","Skeletal Champion",3871
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","44.69%","Epoch Golem",4179
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","23.79%","Portal Plunderer",4179
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","14.86%","Clockwork Timespinner",4179
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","5.72%","Record Keeper's Assistant",4179
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","5.48%","Sentient Slime",4179
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","5.45%","Record Keeper",4179
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","23.79%","Portal Plunderer",4179
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","5.65%","Skeletal Champion",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","43.09%","Clockwork Timespinner",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","39.17%","Portal Plunderer",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","5.65%","Skeletal Champion",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","5.48%","Record Keeper",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","4.41%","Epoch Golem",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","1.13%","Dread Knight",42312
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","0.53%","Sentient Slime",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","0.53%","Record Keeper's Assistant",42312
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","39.17%","Portal Plunderer",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","0.53%","Sentient Slime",42312
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","45.79%","Clockwork Timespinner",47427
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","41.48%","Portal Plunderer",47427
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","5.82%","Record Keeper",47427
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","4.66%","Epoch Golem",47427
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","1.15%","Dread Knight",47427
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","0.56%","Sentient Slime",47427
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","0.55%","Record Keeper's Assistant",47427
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","41.48%","Portal Plunderer",47427
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","6.07%","Sentient Slime",2155
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","1.94%","Dread Knight",2155
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","27.90%","Clockwork Timespinner",2155
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","28.15%","Portal Plunderer",2155
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","27.90%","Clockwork Timespinner",2155
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","17.75%","Record Keeper",2155
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","9.60%","Skeletal Champion",2155
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","8.60%","Record Keeper's Assistant",2155
-"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","6.68%","Sentient Slime",2302
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","6.07%","Sentient Slime",2155
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","1.94%","Dread Knight",2155
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","30.90%","Clockwork Timespinner",2302
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","30.49%","Portal Plunderer",2302
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","20.10%","Record Keeper",2302
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","9.72%","Record Keeper's Assistant",2302
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","6.68%","Sentient Slime",2302
 "Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","2.11%","Dread Knight",2302
-"Bristle Woods Rift","Entrance","Runic String","-","0.62%","Clockwork Timespinner",325
-"Bristle Woods Rift","Entrance","Runic String","-","3.69%","Portal Plunderer",325
-"Bristle Woods Rift","Entrance","Runic String","-","3.08%","Skeletal Champion",325
-"Bristle Woods Rift","Entrance","Runic String","-","3.08%","Epoch Golem",325
-"Bristle Woods Rift","Entrance","Runic String","-","0.62%","Sentient Slime",325
-"Bristle Woods Rift","Entrance","Runic String","-","10.46%","Portal Paladin",325
 "Bristle Woods Rift","Entrance","Runic String","-","78.46%","Vigilant Ward",325
-"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","3.92%","Portal Plunderer",368
-"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","0.56%","Sentient Slime",368
+"Bristle Woods Rift","Entrance","Runic String","-","10.46%","Portal Paladin",325
+"Bristle Woods Rift","Entrance","Runic String","-","3.69%","Portal Plunderer",325
+"Bristle Woods Rift","Entrance","Runic String","-","3.08%","Epoch Golem",325
+"Bristle Woods Rift","Entrance","Runic String","-","3.08%","Skeletal Champion",325
+"Bristle Woods Rift","Entrance","Runic String","-","0.62%","Sentient Slime",325
+"Bristle Woods Rift","Entrance","Runic String","-","0.62%","Clockwork Timespinner",325
 "Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","80.95%","Vigilant Ward",368
 "Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","10.64%","Portal Paladin",368
-"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","0.56%","Clockwork Timespinner",368
+"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","3.92%","Portal Plunderer",368
 "Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","3.36%","Epoch Golem",368
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","0.69%","Sentient Slime",325
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","0.69%","Clockwork Timespinner",325
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","3.44%","Epoch Golem",325
+"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","0.56%","Sentient Slime",368
+"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","0.56%","Clockwork Timespinner",368
 "Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","87.63%","Vigilant Ward",325
 "Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","4.12%","Portal Plunderer",325
 "Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","3.44%","Skeletal Champion",325
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","0.63%","Sentient Slime",368
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","0.63%","Clockwork Timespinner",368
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","3.44%","Epoch Golem",325
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","0.69%","Clockwork Timespinner",325
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","0.69%","Sentient Slime",325
 "Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","90.60%","Vigilant Ward",368
-"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","3.76%","Epoch Golem",368
 "Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","4.39%","Portal Plunderer",368
-"Bristle Woods Rift","Frozen Alcove","Runic String","-","0.51%","Harbinger of Death",4344
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","3.76%","Epoch Golem",368
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","0.63%","Clockwork Timespinner",368
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","0.63%","Sentient Slime",368
+"Bristle Woods Rift","Frozen Alcove","Runic String","-","54.79%","Sentient Slime",4344
 "Bristle Woods Rift","Frozen Alcove","Runic String","-","38.59%","Dread Knight",4344
 "Bristle Woods Rift","Frozen Alcove","Runic String","-","6.11%","Portal Paladin",4344
-"Bristle Woods Rift","Frozen Alcove","Runic String","-","54.79%","Sentient Slime",4344
+"Bristle Woods Rift","Frozen Alcove","Runic String","-","0.51%","Harbinger of Death",4344
+"Bristle Woods Rift","Frozen Alcove","Runic String","Rift Antiskele","54.56%","Sentient Slime",4474
 "Bristle Woods Rift","Frozen Alcove","Runic String","Rift Antiskele","38.79%","Dread Knight",4474
 "Bristle Woods Rift","Frozen Alcove","Runic String","Rift Antiskele","6.15%","Portal Paladin",4474
 "Bristle Woods Rift","Frozen Alcove","Runic String","Rift Antiskele","0.49%","Harbinger of Death",4474
-"Bristle Woods Rift","Frozen Alcove","Runic String","Rift Antiskele","54.56%","Sentient Slime",4474
 "Bristle Woods Rift","Frozen Alcove","Ancient String","-","54.92%","Sentient Slime",1551
 "Bristle Woods Rift","Frozen Alcove","Ancient String","-","36.29%","Dread Knight",1551
 "Bristle Woods Rift","Frozen Alcove","Ancient String","-","8.60%","Portal Paladin",1551
 "Bristle Woods Rift","Frozen Alcove","Ancient String","-","0.19%","Harbinger of Death",1551
+"Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","54.87%","Sentient Slime",1597
+"Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","36.39%","Dread Knight",1597
 "Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","8.55%","Portal Paladin",1597
 "Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","0.19%","Harbinger of Death",1597
-"Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","36.39%","Dread Knight",1597
-"Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","54.87%","Sentient Slime",1597
-"Bristle Woods Rift","Frozen Alcove","Magical String","-","8.50%","Portal Paladin",1353
-"Bristle Woods Rift","Frozen Alcove","Magical String","-","11.75%","Dread Knight",1353
 "Bristle Woods Rift","Frozen Alcove","Magical String","-","79.75%","Sentient Slime",1353
-"Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","11.66%","Dread Knight",1450
-"Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","0.07%","Harbinger of Death",1450
+"Bristle Woods Rift","Frozen Alcove","Magical String","-","11.75%","Dread Knight",1353
+"Bristle Woods Rift","Frozen Alcove","Magical String","-","8.50%","Portal Paladin",1353
 "Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","79.79%","Sentient Slime",1450
+"Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","11.66%","Dread Knight",1450
 "Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","8.48%","Portal Paladin",1450
+"Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","0.07%","Harbinger of Death",1450
 "Bristle Woods Rift","Frozen Alcove","Brie String","-","80.12%","Sentient Slime",1385
 "Bristle Woods Rift","Frozen Alcove","Brie String","-","11.04%","Dread Knight",1385
 "Bristle Woods Rift","Frozen Alcove","Brie String","-","8.85%","Portal Paladin",1385
+"Bristle Woods Rift","Frozen Alcove","Brie String","Rift Antiskele","79.91%","Sentient Slime",1519
 "Bristle Woods Rift","Frozen Alcove","Brie String","Rift Antiskele","11.21%","Dread Knight",1519
 "Bristle Woods Rift","Frozen Alcove","Brie String","Rift Antiskele","8.88%","Portal Paladin",1519
-"Bristle Woods Rift","Frozen Alcove","Brie String","Rift Antiskele","79.91%","Sentient Slime",1519
-"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","-","41.10%","Dread Knight",4344
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","-","58.36%","Sentient Slime",4344
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","-","41.10%","Dread Knight",4344
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","-","0.54%","Harbinger of Death",4344
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","Rift Antiskele","58.14%","Sentient Slime",4474
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","Rift Antiskele","41.33%","Dread Knight",4474
@@ -261,370 +261,371 @@
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","-","60.08%","Sentient Slime",1551
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","-","39.70%","Dread Knight",1551
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","-","0.21%","Harbinger of Death",1551
-"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","Rift Antiskele","0.21%","Harbinger of Death",1597
-"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","Rift Antiskele","39.79%","Dread Knight",1597
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","Rift Antiskele","60.00%","Sentient Slime",1597
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","Rift Antiskele","39.79%","Dread Knight",1597
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","Rift Antiskele","0.21%","Harbinger of Death",1597
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","-","87.16%","Sentient Slime",1353
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","-","12.84%","Dread Knight",1353
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","Rift Antiskele","87.19%","Sentient Slime",1450
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","Rift Antiskele","12.74%","Dread Knight",1450
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","Rift Antiskele","0.08%","Harbinger of Death",1450
-"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","Rift Antiskele","87.19%","Sentient Slime",1450
-"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","-","12.11%","Dread Knight",1385
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","-","87.89%","Sentient Slime",1385
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","-","12.11%","Dread Knight",1385
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","Rift Antiskele","87.69%","Sentient Slime",1519
 "Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","Rift Antiskele","12.31%","Dread Knight",1519
-"Bristle Woods Rift","Furnace Room","Brie String","-","2.80%","Portal Paladin",328
 "Bristle Woods Rift","Furnace Room","Brie String","-","91.90%","Skeletal Champion",328
-"Bristle Woods Rift","Furnace Room","Brie String","-","1.56%","Dread Knight",328
-"Bristle Woods Rift","Furnace Room","Brie String","-","1.87%","Clockwork Timespinner",328
+"Bristle Woods Rift","Furnace Room","Brie String","-","2.80%","Portal Paladin",328
 "Bristle Woods Rift","Furnace Room","Brie String","-","1.87%","Portal Plunderer",328
-"Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","31.25%","Clockwork Timespinner",419
+"Bristle Woods Rift","Furnace Room","Brie String","-","1.87%","Clockwork Timespinner",328
+"Bristle Woods Rift","Furnace Room","Brie String","-","1.56%","Dread Knight",328
 "Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","35.42%","Portal Paladin",419
+"Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","31.25%","Clockwork Timespinner",419
 "Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","16.67%","Dread Knight",419
 "Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","16.67%","Portal Plunderer",419
-"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.92%","Portal Plunderer",328
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","94.55%","Skeletal Champion",328
-"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.60%","Dread Knight",328
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.92%","Clockwork Timespinner",328
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.92%","Portal Plunderer",328
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.60%","Dread Knight",328
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","48.39%","Clockwork Timespinner",419
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","25.81%","Dread Knight",419
 "Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","25.81%","Portal Plunderer",419
-"Bristle Woods Rift","Gearworks","Runic String","-","0.27%","Timelost Thaumaturge",2221
-"Bristle Woods Rift","Gearworks","Runic String","-","0.90%","Record Keeper's Assistant",2221
-"Bristle Woods Rift","Gearworks","Runic String","-","2.17%","Record Keeper",2221
-"Bristle Woods Rift","Gearworks","Runic String","-","25.21%","Chamber Cleaver",2221
-"Bristle Woods Rift","Gearworks","Runic String","-","6.18%","Portal Paladin",2221
 "Bristle Woods Rift","Gearworks","Runic String","-","37.44%","Dread Knight",2221
-"Bristle Woods Rift","Gearworks","Runic String","-","0.05%","Harbinger of Death",2221
-"Bristle Woods Rift","Gearworks","Runic String","-","0.09%","Shackled Servant",2221
-"Bristle Woods Rift","Gearworks","Runic String","-","0.18%","Vigilant Ward",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","25.21%","Chamber Cleaver",2221
 "Bristle Woods Rift","Gearworks","Runic String","-","11.37%","Portal Plunderer",2221
-"Bristle Woods Rift","Gearworks","Runic String","-","4.15%","Clockwork Timespinner",2221
 "Bristle Woods Rift","Gearworks","Runic String","-","8.71%","Skeletal Champion",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","6.18%","Portal Paladin",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","4.15%","Clockwork Timespinner",2221
 "Bristle Woods Rift","Gearworks","Runic String","-","3.29%","Sentient Slime",2221
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.27%","Timelost Thaumaturge",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.05%","Harbinger of Death",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","3.60%","Sentient Slime",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","4.77%","Clockwork Timespinner",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","6.93%","Portal Paladin",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","12.92%","Portal Plunderer",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","26.65%","Chamber Cleaver",2427
+"Bristle Woods Rift","Gearworks","Runic String","-","2.17%","Record Keeper",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","0.90%","Record Keeper's Assistant",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","0.27%","Timelost Thaumaturge",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","0.18%","Vigilant Ward",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","0.09%","Shackled Servant",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","0.05%","Harbinger of Death",2221
 "Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","41.06%","Dread Knight",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.27%","Vigilant Ward",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.05%","Timeslither Pythoness",2427
-"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.99%","Record Keeper's Assistant",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","26.65%","Chamber Cleaver",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","12.92%","Portal Plunderer",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","6.93%","Portal Paladin",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","4.77%","Clockwork Timespinner",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","3.60%","Sentient Slime",2427
 "Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","2.34%","Record Keeper",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.99%","Record Keeper's Assistant",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.27%","Vigilant Ward",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.27%","Timelost Thaumaturge",2427
 "Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.09%","Shackled Servant",2427
-"Bristle Woods Rift","Gearworks","Ancient String","-","8.81%","Sentient Slime",564
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.05%","Timeslither Pythoness",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.05%","Harbinger of Death",2427
 "Bristle Woods Rift","Gearworks","Ancient String","-","38.49%","Dread Knight",564
-"Bristle Woods Rift","Gearworks","Ancient String","-","7.55%","Record Keeper",564
-"Bristle Woods Rift","Gearworks","Ancient String","-","7.91%","Skeletal Champion",564
-"Bristle Woods Rift","Gearworks","Ancient String","-","5.94%","Portal Paladin",564
-"Bristle Woods Rift","Gearworks","Ancient String","-","8.99%","Clockwork Timespinner",564
-"Bristle Woods Rift","Gearworks","Ancient String","-","9.17%","Record Keeper's Assistant",564
 "Bristle Woods Rift","Gearworks","Ancient String","-","13.13%","Portal Plunderer",564
-"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","10.21%","Record Keeper's Assistant",635
+"Bristle Woods Rift","Gearworks","Ancient String","-","9.17%","Record Keeper's Assistant",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","8.99%","Clockwork Timespinner",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","8.81%","Sentient Slime",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","7.91%","Skeletal Champion",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","7.55%","Record Keeper",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","5.94%","Portal Paladin",564
 "Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","41.35%","Dread Knight",635
 "Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","13.84%","Portal Plunderer",635
-"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","10.03%","Sentient Slime",635
+"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","10.21%","Record Keeper's Assistant",635
 "Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","10.03%","Clockwork Timespinner",635
+"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","10.03%","Sentient Slime",635
 "Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","8.13%","Record Keeper",635
 "Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","6.40%","Portal Paladin",635
 "Bristle Woods Rift","Gearworks","Magical String","-","20.61%","Record Keeper's Assistant",2082
-"Bristle Woods Rift","Gearworks","Magical String","-","4.51%","Clockwork Timespinner",2082
-"Bristle Woods Rift","Gearworks","Magical String","-","4.13%","Epoch Golem",2082
-"Bristle Woods Rift","Gearworks","Magical String","-","8.89%","Portal Paladin",2082
-"Bristle Woods Rift","Gearworks","Magical String","-","9.03%","Skeletal Champion",2082
-"Bristle Woods Rift","Gearworks","Magical String","-","4.27%","Portal Plunderer",2082
-"Bristle Woods Rift","Gearworks","Magical String","-","14.65%","Sentient Slime",2082
-"Bristle Woods Rift","Gearworks","Magical String","-","16.47%","Dread Knight",2082
 "Bristle Woods Rift","Gearworks","Magical String","-","17.44%","Record Keeper",2082
-"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","16.22%","Sentient Slime",2232
-"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","4.90%","Clockwork Timespinner",2232
-"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","9.55%","Portal Paladin",2232
-"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","19.55%","Record Keeper",2232
+"Bristle Woods Rift","Gearworks","Magical String","-","16.47%","Dread Knight",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","14.65%","Sentient Slime",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","9.03%","Skeletal Champion",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","8.89%","Portal Paladin",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","4.51%","Clockwork Timespinner",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","4.27%","Portal Plunderer",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","4.13%","Epoch Golem",2082
 "Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","22.54%","Record Keeper's Assistant",2232
-"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","4.51%","Epoch Golem",2232
-"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","4.61%","Portal Plunderer",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","19.55%","Record Keeper",2232
 "Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","18.13%","Dread Knight",2232
-"Bristle Woods Rift","Gearworks","Brie String","-","7.33%","Portal Paladin",13024
-"Bristle Woods Rift","Gearworks","Brie String","-","5.43%","Portal Plunderer",13024
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","16.22%","Sentient Slime",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","9.55%","Portal Paladin",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","4.90%","Clockwork Timespinner",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","4.61%","Portal Plunderer",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","4.51%","Epoch Golem",2232
+"Bristle Woods Rift","Gearworks","Brie String","-","22.75%","Record Keeper's Assistant",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","16.73%","Dread Knight",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","15.08%","Record Keeper",13024
 "Bristle Woods Rift","Gearworks","Brie String","-","13.35%","Sentient Slime",13024
 "Bristle Woods Rift","Gearworks","Brie String","-","11.82%","Skeletal Champion",13024
-"Bristle Woods Rift","Gearworks","Brie String","-","15.08%","Record Keeper",13024
-"Bristle Woods Rift","Gearworks","Brie String","-","16.73%","Dread Knight",13024
-"Bristle Woods Rift","Gearworks","Brie String","-","22.75%","Record Keeper's Assistant",13024
 "Bristle Woods Rift","Gearworks","Brie String","-","7.51%","Clockwork Timespinner",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","7.33%","Portal Paladin",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","5.43%","Portal Plunderer",13024
+"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","25.96%","Record Keeper's Assistant",14344
+"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","18.77%","Dread Knight",14344
 "Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","17.35%","Record Keeper",14344
 "Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","15.10%","Sentient Slime",14344
 "Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","8.33%","Clockwork Timespinner",14344
 "Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","8.31%","Portal Paladin",14344
-"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","18.77%","Dread Knight",14344
-"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","25.96%","Record Keeper's Assistant",14344
 "Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","6.19%","Portal Plunderer",14344
-"Bristle Woods Rift","Gearworks","Swiss String","-","8.52%","Portal Paladin",704
-"Bristle Woods Rift","Gearworks","Swiss String","-","15.48%","Skeletal Champion",704
-"Bristle Woods Rift","Gearworks","Swiss String","-","16.19%","Record Keeper",704
-"Bristle Woods Rift","Gearworks","Swiss String","-","19.18%","Record Keeper's Assistant",704
-"Bristle Woods Rift","Gearworks","Swiss String","-","8.24%","Dread Knight",704
 "Bristle Woods Rift","Gearworks","Swiss String","-","23.72%","Sentient Slime",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","19.18%","Record Keeper's Assistant",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","16.19%","Record Keeper",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","15.48%","Skeletal Champion",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","8.52%","Portal Paladin",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","8.24%","Dread Knight",704
 "Bristle Woods Rift","Gearworks","Swiss String","-","5.40%","Clockwork Timespinner",704
 "Bristle Woods Rift","Gearworks","Swiss String","-","3.27%","Portal Plunderer",704
 "Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","28.73%","Sentient Slime",734
+"Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","22.79%","Record Keeper's Assistant",734
 "Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","18.62%","Record Keeper",734
 "Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","10.27%","Portal Paladin",734
 "Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","9.79%","Dread Knight",734
 "Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","6.10%","Clockwork Timespinner",734
 "Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","3.69%","Portal Plunderer",734
-"Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","22.79%","Record Keeper's Assistant",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","39.90%","Dread Knight",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","26.88%","Chamber Cleaver",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","12.12%","Portal Plunderer",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","9.28%","Skeletal Champion",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","4.42%","Clockwork Timespinner",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","3.51%","Sentient Slime",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","2.31%","Record Keeper",2221
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.96%","Record Keeper's Assistant",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.29%","Timelost Thaumaturge",2221
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.19%","Vigilant Ward",2221
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.10%","Shackled Servant",2221
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.05%","Harbinger of Death",2221
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","9.28%","Skeletal Champion",2221
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","26.88%","Chamber Cleaver",2221
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","39.90%","Dread Knight",2221
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","3.51%","Sentient Slime",2221
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","2.31%","Record Keeper",2221
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","12.12%","Portal Plunderer",2221
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.29%","Timelost Thaumaturge",2221
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","4.42%","Clockwork Timespinner",2221
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.29%","Timelost Thaumaturge",2427
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.29%","Vigilant Ward",2427
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","1.06%","Record Keeper's Assistant",2427
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","44.12%","Dread Knight",2427
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","28.64%","Chamber Cleaver",2427
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","13.88%","Portal Plunderer",2427
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","2.52%","Record Keeper",2427
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","3.87%","Sentient Slime",2427
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","5.13%","Clockwork Timespinner",2427
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.05%","Timeslither Pythoness",2427
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.05%","Harbinger of Death",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","3.87%","Sentient Slime",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","2.52%","Record Keeper",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","1.06%","Record Keeper's Assistant",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.29%","Vigilant Ward",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.29%","Timelost Thaumaturge",2427
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.10%","Shackled Servant",2427
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","8.41%","Skeletal Champion",564
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","9.37%","Sentient Slime",564
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","9.56%","Clockwork Timespinner",564
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","9.75%","Record Keeper's Assistant",564
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","13.96%","Portal Plunderer",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.05%","Harbinger of Death",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.05%","Timeslither Pythoness",2427
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","40.92%","Dread Knight",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","13.96%","Portal Plunderer",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","9.75%","Record Keeper's Assistant",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","9.56%","Clockwork Timespinner",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","9.37%","Sentient Slime",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","8.41%","Skeletal Champion",564
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","8.03%","Record Keeper",564
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","10.72%","Clockwork Timespinner",635
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","44.18%","Dread Knight",635
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","14.79%","Portal Plunderer",635
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","10.91%","Record Keeper's Assistant",635
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","44.18%","Dread Knight",635
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","8.69%","Record Keeper",635
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","10.72%","Clockwork Timespinner",635
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","10.72%","Sentient Slime",635
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","4.69%","Portal Plunderer",2082
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","4.96%","Clockwork Timespinner",2082
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","9.91%","Skeletal Champion",2082
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","16.08%","Sentient Slime",2082
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","18.08%","Dread Knight",2082
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","19.14%","Record Keeper",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","8.69%","Record Keeper",635
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","22.61%","Record Keeper's Assistant",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","19.14%","Record Keeper",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","18.08%","Dread Knight",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","16.08%","Sentient Slime",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","9.91%","Skeletal Champion",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","4.96%","Clockwork Timespinner",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","4.69%","Portal Plunderer",2082
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","4.53%","Epoch Golem",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","24.92%","Record Keeper's Assistant",2232
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","21.61%","Record Keeper",2232
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","20.04%","Dread Knight",2232
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","17.93%","Sentient Slime",2232
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","5.42%","Clockwork Timespinner",2232
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","5.09%","Portal Plunderer",2232
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","4.98%","Epoch Golem",2232
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","24.92%","Record Keeper's Assistant",2232
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","21.61%","Record Keeper",2232
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","24.55%","Record Keeper's Assistant",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","18.05%","Dread Knight",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","16.28%","Record Keeper",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","14.41%","Sentient Slime",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","12.76%","Skeletal Champion",13024
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","8.10%","Clockwork Timespinner",13024
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","5.85%","Portal Plunderer",13024
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","24.55%","Record Keeper's Assistant",13024
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","12.76%","Skeletal Champion",13024
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","14.41%","Sentient Slime",13024
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","16.28%","Record Keeper",13024
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","18.05%","Dread Knight",13024
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","6.75%","Portal Plunderer",14344
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","16.46%","Sentient Slime",14344
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","18.92%","Record Keeper",14344
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","20.47%","Dread Knight",14344
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","9.09%","Clockwork Timespinner",14344
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","28.31%","Record Keeper's Assistant",14344
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","16.93%","Skeletal Champion",704
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","9.01%","Dread Knight",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","20.47%","Dread Knight",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","18.92%","Record Keeper",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","16.46%","Sentient Slime",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","9.09%","Clockwork Timespinner",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","6.75%","Portal Plunderer",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","25.93%","Sentient Slime",704
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","20.96%","Record Keeper's Assistant",704
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","17.70%","Record Keeper",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","16.93%","Skeletal Champion",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","9.01%","Dread Knight",704
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","5.90%","Clockwork Timespinner",704
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","3.57%","Portal Plunderer",704
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","25.93%","Sentient Slime",704
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","20.75%","Record Keeper",734
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","25.40%","Record Keeper's Assistant",734
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","32.02%","Sentient Slime",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","25.40%","Record Keeper's Assistant",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","20.75%","Record Keeper",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","10.91%","Dread Knight",734
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","6.80%","Clockwork Timespinner",734
 "Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","4.11%","Portal Plunderer",734
-"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","10.91%","Dread Knight",734
-"Bristle Woods Rift","Guard Barracks","Runic String","-","1.06%","Sentient Slime",6785
 "Bristle Woods Rift","Guard Barracks","Runic String","-","65.46%","Portal Paladin",6785
 "Bristle Woods Rift","Guard Barracks","Runic String","-","17.98%","Dread Knight",6785
 "Bristle Woods Rift","Guard Barracks","Runic String","-","13.45%","Epoch Golem",6785
 "Bristle Woods Rift","Guard Barracks","Runic String","-","2.05%","Clockwork Timespinner",6785
-"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","2.01%","Clockwork Timespinner",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","-","1.06%","Sentient Slime",6785
 "Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","65.45%","Portal Paladin",6969
 "Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","18.05%","Dread Knight",6969
 "Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","13.45%","Epoch Golem",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","2.01%","Clockwork Timespinner",6969
 "Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","1.03%","Sentient Slime",6969
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","6.19%","Clockwork Timespinner",2029
 "Bristle Woods Rift","Guard Barracks","Ancient String","-","57.48%","Portal Paladin",2029
 "Bristle Woods Rift","Guard Barracks","Ancient String","-","15.56%","Dread Knight",2029
 "Bristle Woods Rift","Guard Barracks","Ancient String","-","11.55%","Sentient Slime",2029
 "Bristle Woods Rift","Guard Barracks","Ancient String","-","9.22%","Epoch Golem",2029
-"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","9.36%","Epoch Golem",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","6.19%","Clockwork Timespinner",2029
 "Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","57.16%","Portal Paladin",2084
 "Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","15.77%","Dread Knight",2084
 "Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","11.58%","Sentient Slime",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","9.36%","Epoch Golem",2084
 "Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","6.13%","Clockwork Timespinner",2084
-"Bristle Woods Rift","Guard Barracks","Magical String","-","11.96%","Epoch Golem",1864
-"Bristle Woods Rift","Guard Barracks","Magical String","-","14.38%","Clockwork Timespinner",1864
-"Bristle Woods Rift","Guard Barracks","Magical String","-","18.03%","Sentient Slime",1864
-"Bristle Woods Rift","Guard Barracks","Magical String","-","10.57%","Dread Knight",1864
 "Bristle Woods Rift","Guard Barracks","Magical String","-","45.06%","Portal Paladin",1864
-"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","10.55%","Dread Knight",1896
-"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","18.04%","Sentient Slime",1896
-"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","11.97%","Epoch Golem",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","-","18.03%","Sentient Slime",1864
+"Bristle Woods Rift","Guard Barracks","Magical String","-","14.38%","Clockwork Timespinner",1864
+"Bristle Woods Rift","Guard Barracks","Magical String","-","11.96%","Epoch Golem",1864
+"Bristle Woods Rift","Guard Barracks","Magical String","-","10.57%","Dread Knight",1864
 "Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","44.94%","Portal Paladin",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","18.04%","Sentient Slime",1896
 "Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","14.50%","Clockwork Timespinner",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","11.97%","Epoch Golem",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","10.55%","Dread Knight",1896
 "Bristle Woods Rift","Guard Barracks","Brie String","-","41.27%","Portal Paladin",2154
-"Bristle Woods Rift","Guard Barracks","Brie String","-","9.01%","Dread Knight",2154
-"Bristle Woods Rift","Guard Barracks","Brie String","-","23.11%","Sentient Slime",2154
 "Bristle Woods Rift","Guard Barracks","Brie String","-","26.61%","Clockwork Timespinner",2154
-"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","23.07%","Sentient Slime",2309
-"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","9.19%","Dread Knight",2309
+"Bristle Woods Rift","Guard Barracks","Brie String","-","23.11%","Sentient Slime",2154
+"Bristle Woods Rift","Guard Barracks","Brie String","-","9.01%","Dread Knight",2154
 "Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","41.05%","Portal Paladin",2309
 "Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","26.69%","Clockwork Timespinner",2309
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","3.08%","Sentient Slime",6785
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","5.94%","Clockwork Timespinner",6785
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","38.93%","Epoch Golem",6785
+"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","23.07%","Sentient Slime",2309
+"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","9.19%","Dread Knight",2309
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","52.05%","Dread Knight",6785
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","38.93%","Epoch Golem",6785
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","5.94%","Clockwork Timespinner",6785
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","3.08%","Sentient Slime",6785
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","52.25%","Dread Knight",6969
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","38.94%","Epoch Golem",6969
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","5.82%","Clockwork Timespinner",6969
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","3.00%","Sentient Slime",6969
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","21.68%","Epoch Golem",2029
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","27.16%","Sentient Slime",2029
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","36.60%","Dread Knight",2029
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","27.16%","Sentient Slime",2029
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","21.68%","Epoch Golem",2029
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","14.57%","Clockwork Timespinner",2029
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","14.30%","Clockwork Timespinner",2084
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","27.03%","Sentient Slime",2084
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","36.82%","Dread Knight",2084
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","27.03%","Sentient Slime",2084
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","21.85%","Epoch Golem",2084
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","14.30%","Clockwork Timespinner",2084
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","32.81%","Sentient Slime",1864
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","26.17%","Clockwork Timespinner",1864
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","21.78%","Epoch Golem",1864
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","19.24%","Dread Knight",1864
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","32.76%","Sentient Slime",1896
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","26.34%","Clockwork Timespinner",1896
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","19.16%","Dread Knight",1896
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","21.74%","Epoch Golem",1896
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","19.16%","Dread Knight",1896
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","45.31%","Clockwork Timespinner",2154
-"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","15.34%","Dread Knight",2154
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","39.35%","Sentient Slime",2154
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","15.34%","Dread Knight",2154
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","Rift Antiskele","45.27%","Clockwork Timespinner",2309
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","Rift Antiskele","39.14%","Sentient Slime",2309
 "Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","Rift Antiskele","15.58%","Dread Knight",2309
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","9.26%","Epoch Golem",842
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.75%","Shackled Servant",842
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","5.94%","Dread Knight",842
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.16%","Portal Paladin",842
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","11.88%","Portal Plunderer",842
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.28%","Skeletal Champion",842
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.51%","Carrion Medium",842
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","2.14%","Harbinger of Death",842
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","25.89%","Timeslither Pythoness",842
 "Bristle Woods Rift","Hidden Treasury","Runic String","-","27.20%","Timeless Lich",842
-"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","6.03%","Dread Knight",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","25.89%","Timeslither Pythoness",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","11.88%","Portal Plunderer",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","9.26%","Epoch Golem",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","5.94%","Dread Knight",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.75%","Shackled Servant",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.51%","Carrion Medium",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.28%","Skeletal Champion",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.16%","Portal Paladin",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","2.14%","Harbinger of Death",842
 "Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","27.96%","Timeless Lich",950
 "Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","26.64%","Timeslither Pythoness",950
 "Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","12.28%","Portal Plunderer",950
 "Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","9.98%","Epoch Golem",950
-"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","2.19%","Harbinger of Death",950
-"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","4.71%","Carrion Medium",950
-"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","4.93%","Portal Paladin",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","6.03%","Dread Knight",950
 "Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","5.26%","Shackled Servant",950
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","5.74%","Dread Knight",366
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","3.55%","Skeletal Champion",366
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","16.39%","Timeless Lich",366
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","19.95%","Epoch Golem",366
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","4.93%","Portal Paladin",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","4.71%","Carrion Medium",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","2.19%","Harbinger of Death",950
 "Bristle Woods Rift","Hidden Treasury","Ancient String","-","23.77%","Timeslither Pythoness",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","19.95%","Epoch Golem",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","16.39%","Timeless Lich",366
 "Bristle Woods Rift","Hidden Treasury","Ancient String","-","13.93%","Portal Plunderer",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","5.74%","Dread Knight",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","5.46%","Carrion Medium",366
 "Bristle Woods Rift","Hidden Treasury","Ancient String","-","5.46%","Portal Paladin",366
 "Bristle Woods Rift","Hidden Treasury","Ancient String","-","4.10%","Shackled Servant",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","3.55%","Skeletal Champion",366
 "Bristle Woods Rift","Hidden Treasury","Ancient String","-","1.64%","Harbinger of Death",366
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","5.46%","Carrion Medium",366
-"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","5.11%","Portal Paladin",425
-"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","5.84%","Dread Knight",425
-"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","1.70%","Harbinger of Death",425
-"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","4.14%","Shackled Servant",425
-"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","4.87%","Carrion Medium",425
 "Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","26.03%","Timeslither Pythoness",425
 "Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","20.19%","Epoch Golem",425
 "Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","18.00%","Timeless Lich",425
 "Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","14.11%","Portal Plunderer",425
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","1.55%","Harbinger of Death",388
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","3.87%","Carrion Medium",388
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","4.90%","Shackled Servant",388
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","5.93%","Dread Knight",388
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","6.19%","Portal Paladin",388
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","6.44%","Skeletal Champion",388
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","10.57%","Portal Plunderer",388
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","10.82%","Timeslither Pythoness",388
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","12.89%","Timeless Lich",388
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","5.84%","Dread Knight",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","5.11%","Portal Paladin",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","4.87%","Carrion Medium",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","4.14%","Shackled Servant",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","1.70%","Harbinger of Death",425
 "Bristle Woods Rift","Hidden Treasury","Magical String","-","36.86%","Epoch Golem",388
-"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","6.74%","Portal Paladin",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","12.89%","Timeless Lich",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","10.82%","Timeslither Pythoness",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","10.57%","Portal Plunderer",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","6.44%","Skeletal Champion",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","6.19%","Portal Paladin",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","5.93%","Dread Knight",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","4.90%","Shackled Servant",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","3.87%","Carrion Medium",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","1.55%","Harbinger of Death",388
 "Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","38.37%","Epoch Golem",458
 "Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","13.95%","Timeless Lich",458
 "Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","11.86%","Timeslither Pythoness",458
 "Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","11.40%","Portal Plunderer",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","6.74%","Portal Paladin",458
 "Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","6.05%","Shackled Servant",458
 "Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","5.35%","Dread Knight",458
 "Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","4.42%","Carrion Medium",458
 "Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","1.86%","Harbinger of Death",458
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","10.21%","Timeless Lich",1874
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","2.14%","Harbinger of Death",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","35.78%","Portal Plunderer",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","11.55%","Dread Knight",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","10.86%","Timeslither Pythoness",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","10.21%","Timeless Lich",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","8.72%","Epoch Golem",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","6.15%","Carrion Medium",1874
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","5.03%","Skeletal Champion",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","5.03%","Shackled Servant",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","5.03%","Skeletal Champion",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","-","4.55%","Portal Paladin",1874
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","2.30%","Harbinger of Death",2237
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","10.76%","Timeless Lich",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","2.14%","Harbinger of Death",1874
 "Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","38.19%","Portal Plunderer",2237
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","4.60%","Portal Paladin",2237
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","11.27%","Timeslither Pythoness",2237
 "Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","12.26%","Dread Knight",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","11.27%","Timeslither Pythoness",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","10.76%","Timeless Lich",2237
 "Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","9.07%","Epoch Golem",2237
 "Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","6.58%","Carrion Medium",2237
 "Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","4.98%","Shackled Servant",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","4.60%","Portal Paladin",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","2.30%","Harbinger of Death",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","28.38%","Timeless Lich",842
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","27.01%","Timeslither Pythoness",842
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","12.39%","Portal Plunderer",842
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","4.71%","Carrion Medium",842
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","4.46%","Skeletal Champion",842
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","2.23%","Harbinger of Death",842
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","28.38%","Timeless Lich",842
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","9.67%","Epoch Golem",842
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","6.20%","Dread Knight",842
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","4.96%","Shackled Servant",842
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","4.96%","Carrion Medium",950
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","5.54%","Shackled Servant",950
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","12.92%","Portal Plunderer",950
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","28.03%","Timeslither Pythoness",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","4.71%","Carrion Medium",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","4.46%","Skeletal Champion",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","2.23%","Harbinger of Death",842
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","29.41%","Timeless Lich",950
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","6.34%","Dread Knight",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","28.03%","Timeslither Pythoness",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","12.92%","Portal Plunderer",950
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","10.50%","Epoch Golem",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","6.34%","Dread Knight",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","5.54%","Shackled Servant",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","4.96%","Carrion Medium",950
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","2.31%","Harbinger of Death",950
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","21.10%","Epoch Golem",366
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","25.14%","Timeslither Pythoness",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","21.10%","Epoch Golem",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","17.34%","Timeless Lich",366
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","14.74%","Portal Plunderer",366
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","6.07%","Dread Knight",366
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","5.78%","Carrion Medium",366
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","4.34%","Shackled Servant",366
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","3.76%","Skeletal Champion",366
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","1.73%","Harbinger of Death",366
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","17.34%","Timeless Lich",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","27.44%","Timeslither Pythoness",425
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","21.28%","Epoch Golem",425
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","18.97%","Timeless Lich",425
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","14.87%","Portal Plunderer",425
@@ -632,232 +633,229 @@
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","5.13%","Carrion Medium",425
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","4.36%","Shackled Servant",425
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","1.79%","Harbinger of Death",425
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","27.44%","Timeslither Pythoness",425
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","11.54%","Timeslither Pythoness",388
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","39.29%","Epoch Golem",388
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","13.74%","Timeless Lich",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","11.54%","Timeslither Pythoness",388
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","11.26%","Portal Plunderer",388
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","6.87%","Skeletal Champion",388
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","6.32%","Dread Knight",388
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","5.22%","Shackled Servant",388
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","4.12%","Carrion Medium",388
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","1.65%","Harbinger of Death",388
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","2.00%","Harbinger of Death",458
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","4.74%","Carrion Medium",458
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","5.74%","Dread Knight",458
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","6.48%","Shackled Servant",458
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","12.22%","Portal Plunderer",458
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","12.72%","Timeslither Pythoness",458
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","14.96%","Timeless Lich",458
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","41.15%","Epoch Golem",458
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","12.10%","Dread Knight",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","14.96%","Timeless Lich",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","12.72%","Timeslither Pythoness",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","12.22%","Portal Plunderer",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","6.48%","Shackled Servant",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","5.74%","Dread Knight",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","4.74%","Carrion Medium",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","2.00%","Harbinger of Death",458
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","37.48%","Portal Plunderer",1874
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","5.27%","Skeletal Champion",1874
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","5.27%","Shackled Servant",1874
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","6.44%","Carrion Medium",1874
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","9.13%","Epoch Golem",1874
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","2.24%","Harbinger of Death",1874
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","10.70%","Timeless Lich",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","12.10%","Dread Knight",1874
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","11.37%","Timeslither Pythoness",1874
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","9.50%","Epoch Golem",2237
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","6.89%","Carrion Medium",2237
-"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","5.22%","Shackled Servant",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","10.70%","Timeless Lich",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","9.13%","Epoch Golem",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","6.44%","Carrion Medium",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","5.27%","Shackled Servant",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","5.27%","Skeletal Champion",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","2.24%","Harbinger of Death",1874
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","40.03%","Portal Plunderer",2237
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","12.85%","Dread Knight",2237
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","11.82%","Timeslither Pythoness",2237
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","11.28%","Timeless Lich",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","9.50%","Epoch Golem",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","6.89%","Carrion Medium",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","5.22%","Shackled Servant",2237
 "Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","2.41%","Harbinger of Death",2237
+"Bristle Woods Rift","Ingress","Runic String","-","24.83%","Sentient Slime",2365
+"Bristle Woods Rift","Ingress","Runic String","-","24.67%","Clockwork Timespinner",2365
 "Bristle Woods Rift","Ingress","Runic String","-","23.57%","Dread Knight",2365
 "Bristle Woods Rift","Ingress","Runic String","-","14.30%","Vigilant Ward",2365
-"Bristle Woods Rift","Ingress","Runic String","-","24.67%","Clockwork Timespinner",2365
-"Bristle Woods Rift","Ingress","Runic String","-","24.83%","Sentient Slime",2365
 "Bristle Woods Rift","Ingress","Runic String","-","11.31%","Shackled Servant",2365
 "Bristle Woods Rift","Ingress","Runic String","-","1.31%","Harbinger of Death",2365
-"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","23.28%","Dread Knight",2453
-"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","24.59%","Sentient Slime",2453
 "Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","25.04%","Clockwork Timespinner",2453
+"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","24.59%","Sentient Slime",2453
+"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","23.28%","Dread Knight",2453
+"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","14.43%","Vigilant Ward",2453
 "Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","11.41%","Shackled Servant",2453
 "Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","1.26%","Harbinger of Death",2453
-"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","14.43%","Vigilant Ward",2453
-"Bristle Woods Rift","Ingress","Ancient String","-","20.28%","Sentient Slime",761
 "Bristle Woods Rift","Ingress","Ancient String","-","26.92%","Clockwork Timespinner",761
-"Bristle Woods Rift","Ingress","Ancient String","-","1.75%","Harbinger of Death",761
-"Bristle Woods Rift","Ingress","Ancient String","-","15.03%","Vigilant Ward",761
-"Bristle Woods Rift","Ingress","Ancient String","-","16.08%","Shackled Servant",761
+"Bristle Woods Rift","Ingress","Ancient String","-","20.28%","Sentient Slime",761
 "Bristle Woods Rift","Ingress","Ancient String","-","19.93%","Dread Knight",761
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","22.07%","Sentient Slime",862
+"Bristle Woods Rift","Ingress","Ancient String","-","16.08%","Shackled Servant",761
+"Bristle Woods Rift","Ingress","Ancient String","-","15.03%","Vigilant Ward",761
+"Bristle Woods Rift","Ingress","Ancient String","-","1.75%","Harbinger of Death",761
 "Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","26.48%","Clockwork Timespinner",862
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","1.52%","Harbinger of Death",862
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","14.61%","Vigilant Ward",862
-"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","15.98%","Shackled Servant",862
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","22.07%","Sentient Slime",862
 "Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","19.33%","Dread Knight",862
-"Bristle Woods Rift","Ingress","Magical String","-","14.02%","Vigilant Ward",431
-"Bristle Woods Rift","Ingress","Magical String","-","31.06%","Clockwork Timespinner",431
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","15.98%","Shackled Servant",862
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","14.61%","Vigilant Ward",862
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","1.52%","Harbinger of Death",862
 "Bristle Woods Rift","Ingress","Magical String","-","31.82%","Sentient Slime",431
-"Bristle Woods Rift","Ingress","Magical String","-","2.27%","Harbinger of Death",431
-"Bristle Woods Rift","Ingress","Magical String","-","5.30%","Dread Knight",431
+"Bristle Woods Rift","Ingress","Magical String","-","31.06%","Clockwork Timespinner",431
 "Bristle Woods Rift","Ingress","Magical String","-","15.53%","Shackled Servant",431
+"Bristle Woods Rift","Ingress","Magical String","-","14.02%","Vigilant Ward",431
+"Bristle Woods Rift","Ingress","Magical String","-","5.30%","Dread Knight",431
+"Bristle Woods Rift","Ingress","Magical String","-","2.27%","Harbinger of Death",431
 "Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","31.70%","Sentient Slime",432
 "Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","30.94%","Clockwork Timespinner",432
 "Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","15.47%","Shackled Servant",432
-"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","2.26%","Harbinger of Death",432
-"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","5.28%","Dread Knight",432
 "Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","14.34%","Vigilant Ward",432
-"Bristle Woods Rift","Ingress","Brie String","-","4.30%","Dread Knight",992
+"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","5.28%","Dread Knight",432
+"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","2.26%","Harbinger of Death",432
 "Bristle Woods Rift","Ingress","Brie String","-","39.78%","Sentient Slime",992
-"Bristle Woods Rift","Ingress","Brie String","-","9.52%","Shackled Servant",992
-"Bristle Woods Rift","Ingress","Brie String","-","13.67%","Vigilant Ward",992
-"Bristle Woods Rift","Ingress","Brie String","-","2.30%","Harbinger of Death",992
 "Bristle Woods Rift","Ingress","Brie String","-","30.41%","Clockwork Timespinner",992
+"Bristle Woods Rift","Ingress","Brie String","-","13.67%","Vigilant Ward",992
+"Bristle Woods Rift","Ingress","Brie String","-","9.52%","Shackled Servant",992
+"Bristle Woods Rift","Ingress","Brie String","-","4.30%","Dread Knight",992
+"Bristle Woods Rift","Ingress","Brie String","-","2.30%","Harbinger of Death",992
+"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","39.66%","Sentient Slime",1061
 "Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","31.30%","Clockwork Timespinner",1061
 "Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","13.31%","Vigilant Ward",1061
 "Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","9.35%","Shackled Servant",1061
 "Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","4.25%","Dread Knight",1061
-"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","39.66%","Sentient Slime",1061
 "Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","2.12%","Harbinger of Death",1061
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","23.57%","Dread Knight",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","1.31%","Harbinger of Death",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","11.31%","Shackled Servant",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","14.30%","Vigilant Ward",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","24.67%","Clockwork Timespinner",2365
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","24.83%","Sentient Slime",2365
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","11.41%","Shackled Servant",2453
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","14.43%","Vigilant Ward",2453
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","1.26%","Harbinger of Death",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","24.67%","Clockwork Timespinner",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","23.57%","Dread Knight",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","14.30%","Vigilant Ward",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","11.31%","Shackled Servant",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","1.31%","Harbinger of Death",2365
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","25.04%","Clockwork Timespinner",2453
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","24.59%","Sentient Slime",2453
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","23.28%","Dread Knight",2453
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","15.03%","Vigilant Ward",761
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","16.08%","Shackled Servant",761
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","19.93%","Dread Knight",761
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","20.28%","Sentient Slime",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","14.43%","Vigilant Ward",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","11.41%","Shackled Servant",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","1.26%","Harbinger of Death",2453
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","26.92%","Clockwork Timespinner",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","20.28%","Sentient Slime",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","19.93%","Dread Knight",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","16.08%","Shackled Servant",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","15.03%","Vigilant Ward",761
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","1.75%","Harbinger of Death",761
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","26.48%","Clockwork Timespinner",862
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","22.07%","Sentient Slime",862
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","14.61%","Vigilant Ward",862
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","1.52%","Harbinger of Death",862
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","19.33%","Dread Knight",862
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","15.98%","Shackled Servant",862
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","31.06%","Clockwork Timespinner",431
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","14.61%","Vigilant Ward",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","1.52%","Harbinger of Death",862
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","31.82%","Sentient Slime",431
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","31.06%","Clockwork Timespinner",431
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","15.53%","Shackled Servant",431
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","14.02%","Vigilant Ward",431
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","5.30%","Dread Knight",431
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","2.27%","Harbinger of Death",431
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","15.53%","Shackled Servant",431
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","2.26%","Harbinger of Death",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","30.94%","Clockwork Timespinner",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","14.34%","Vigilant Ward",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","15.47%","Shackled Servant",432
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","31.70%","Sentient Slime",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","30.94%","Clockwork Timespinner",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","15.47%","Shackled Servant",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","14.34%","Vigilant Ward",432
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","5.28%","Dread Knight",432
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","30.41%","Clockwork Timespinner",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","2.26%","Harbinger of Death",432
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","39.78%","Sentient Slime",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","2.30%","Harbinger of Death",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","4.30%","Dread Knight",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","9.52%","Shackled Servant",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","30.41%","Clockwork Timespinner",992
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","13.67%","Vigilant Ward",992
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","9.35%","Shackled Servant",1061
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","13.31%","Vigilant Ward",1061
-"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","31.30%","Clockwork Timespinner",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","9.52%","Shackled Servant",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","4.30%","Dread Knight",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","2.30%","Harbinger of Death",992
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","39.66%","Sentient Slime",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","31.30%","Clockwork Timespinner",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","13.31%","Vigilant Ward",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","9.35%","Shackled Servant",1061
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","4.25%","Dread Knight",1061
 "Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","2.12%","Harbinger of Death",1061
-"Bristle Woods Rift","Lucky Tower","Runic String","-","5.52%","Skeletal Champion",1052
 "Bristle Woods Rift","Lucky Tower","Runic String","-","23.31%","Epoch Golem",1052
-"Bristle Woods Rift","Lucky Tower","Runic String","-","9.80%","Record Keeper's Assistant",1052
-"Bristle Woods Rift","Lucky Tower","Runic String","-","5.42%","Portal Paladin",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","15.60%","Portal Plunderer",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","13.32%","Clockwork Timespinner",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","11.80%","Dread Knight",1052
 "Bristle Woods Rift","Lucky Tower","Runic String","-","10.37%","Record Keeper",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","9.80%","Record Keeper's Assistant",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","5.52%","Skeletal Champion",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","5.42%","Portal Paladin",1052
 "Bristle Woods Rift","Lucky Tower","Runic String","-","2.85%","Sentient Slime",1052
 "Bristle Woods Rift","Lucky Tower","Runic String","-","2.00%","Harbinger of Death",1052
-"Bristle Woods Rift","Lucky Tower","Runic String","-","11.80%","Dread Knight",1052
-"Bristle Woods Rift","Lucky Tower","Runic String","-","13.32%","Clockwork Timespinner",1052
-"Bristle Woods Rift","Lucky Tower","Runic String","-","15.60%","Portal Plunderer",1052
-"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","3.12%","Sentient Slime",1246
 "Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","24.20%","Epoch Golem",1246
 "Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","17.03%","Portal Plunderer",1246
 "Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","13.58%","Clockwork Timespinner",1246
-"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","1.94%","Harbinger of Death",1246
-"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","5.56%","Portal Paladin",1246
-"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","10.71%","Record Keeper",1246
-"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","10.88%","Record Keeper's Assistant",1246
 "Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","12.98%","Dread Knight",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","10.88%","Record Keeper's Assistant",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","10.71%","Record Keeper",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","5.56%","Portal Paladin",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","3.12%","Sentient Slime",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","1.94%","Harbinger of Death",1246
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","22.50%","Epoch Golem",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","16.35%","Portal Plunderer",520
 "Bristle Woods Rift","Lucky Tower","Ancient String","-","14.62%","Clockwork Timespinner",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","10.77%","Record Keeper",520
 "Bristle Woods Rift","Lucky Tower","Ancient String","-","10.38%","Dread Knight",520
 "Bristle Woods Rift","Lucky Tower","Ancient String","-","9.62%","Record Keeper's Assistant",520
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","22.50%","Epoch Golem",520
 "Bristle Woods Rift","Lucky Tower","Ancient String","-","7.12%","Portal Paladin",520
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","10.77%","Record Keeper",520
 "Bristle Woods Rift","Lucky Tower","Ancient String","-","4.62%","Skeletal Champion",520
 "Bristle Woods Rift","Lucky Tower","Ancient String","-","2.69%","Sentient Slime",520
 "Bristle Woods Rift","Lucky Tower","Ancient String","-","1.35%","Harbinger of Death",520
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","16.35%","Portal Plunderer",520
-"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","2.94%","Sentient Slime",604
-"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","6.40%","Portal Paladin",604
-"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","10.55%","Record Keeper's Assistant",604
-"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","11.07%","Dread Knight",604
-"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","11.42%","Record Keeper",604
-"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","15.40%","Clockwork Timespinner",604
-"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","17.30%","Portal Plunderer",604
-"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","1.90%","Harbinger of Death",604
 "Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","23.01%","Epoch Golem",604
-"Bristle Woods Rift","Lucky Tower","Magical String","-","13.03%","Portal Plunderer",591
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","17.30%","Portal Plunderer",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","15.40%","Clockwork Timespinner",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","11.42%","Record Keeper",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","11.07%","Dread Knight",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","10.55%","Record Keeper's Assistant",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","6.40%","Portal Paladin",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","2.94%","Sentient Slime",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","1.90%","Harbinger of Death",604
 "Bristle Woods Rift","Lucky Tower","Magical String","-","22.84%","Epoch Golem",591
 "Bristle Woods Rift","Lucky Tower","Magical String","-","17.43%","Clockwork Timespinner",591
-"Bristle Woods Rift","Lucky Tower","Magical String","-","2.37%","Harbinger of Death",591
-"Bristle Woods Rift","Lucky Tower","Magical String","-","4.06%","Sentient Slime",591
-"Bristle Woods Rift","Lucky Tower","Magical String","-","4.23%","Portal Paladin",591
-"Bristle Woods Rift","Lucky Tower","Magical String","-","5.08%","Skeletal Champion",591
-"Bristle Woods Rift","Lucky Tower","Magical String","-","9.98%","Dread Knight",591
-"Bristle Woods Rift","Lucky Tower","Magical String","-","10.49%","Record Keeper",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","13.03%","Portal Plunderer",591
 "Bristle Woods Rift","Lucky Tower","Magical String","-","10.49%","Record Keeper's Assistant",591
-"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","17.96%","Clockwork Timespinner",727
-"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","4.31%","Sentient Slime",727
-"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","2.44%","Harbinger of Death",727
-"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","4.17%","Portal Paladin",727
-"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","9.77%","Record Keeper's Assistant",727
-"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","10.63%","Dread Knight",727
+"Bristle Woods Rift","Lucky Tower","Magical String","-","10.49%","Record Keeper",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","9.98%","Dread Knight",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","5.08%","Skeletal Champion",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","4.23%","Portal Paladin",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","4.06%","Sentient Slime",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","2.37%","Harbinger of Death",591
 "Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","24.28%","Epoch Golem",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","17.96%","Clockwork Timespinner",727
 "Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","14.80%","Portal Plunderer",727
 "Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","11.64%","Record Keeper",727
-"Bristle Woods Rift","Lucky Tower","Brie String","-","10.41%","Dread Knight",2632
-"Bristle Woods Rift","Lucky Tower","Brie String","-","5.18%","Skeletal Champion",2632
-"Bristle Woods Rift","Lucky Tower","Brie String","-","5.60%","Epoch Golem",2632
-"Bristle Woods Rift","Lucky Tower","Brie String","-","4.31%","Portal Paladin",2632
-"Bristle Woods Rift","Lucky Tower","Brie String","-","10.33%","Sentient Slime",2632
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","10.63%","Dread Knight",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","9.77%","Record Keeper's Assistant",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","4.31%","Sentient Slime",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","4.17%","Portal Paladin",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","2.44%","Harbinger of Death",727
 "Bristle Woods Rift","Lucky Tower","Brie String","-","20.40%","Clockwork Timespinner",2632
 "Bristle Woods Rift","Lucky Tower","Brie String","-","20.24%","Portal Plunderer",2632
-"Bristle Woods Rift","Lucky Tower","Brie String","-","1.52%","Harbinger of Death",2632
 "Bristle Woods Rift","Lucky Tower","Brie String","-","11.02%","Record Keeper",2632
 "Bristle Woods Rift","Lucky Tower","Brie String","-","10.98%","Record Keeper's Assistant",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","10.41%","Dread Knight",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","10.33%","Sentient Slime",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","5.60%","Epoch Golem",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","5.18%","Skeletal Champion",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","4.31%","Portal Paladin",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","1.52%","Harbinger of Death",2632
 "Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","21.49%","Clockwork Timespinner",3109
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.24%","Dread Knight",3109
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.37%","Record Keeper's Assistant",3109
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","10.76%","Sentient Slime",3109
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","4.58%","Portal Paladin",3109
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.81%","Record Keeper",3109
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","1.70%","Harbinger of Death",3109
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","5.87%","Epoch Golem",3109
 "Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","21.18%","Portal Plunderer",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.81%","Record Keeper",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.37%","Record Keeper's Assistant",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.24%","Dread Knight",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","10.76%","Sentient Slime",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","5.87%","Epoch Golem",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","4.58%","Portal Paladin",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","1.70%","Harbinger of Death",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","24.65%","Epoch Golem",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","16.50%","Portal Plunderer",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","14.08%","Clockwork Timespinner",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","12.47%","Dread Knight",1052
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","10.97%","Record Keeper",1052
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","10.36%","Record Keeper's Assistant",1052
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","5.84%","Skeletal Champion",1052
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","3.02%","Sentient Slime",1052
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","2.11%","Harbinger of Death",1052
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","24.65%","Epoch Golem",1052
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","16.50%","Portal Plunderer",1052
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","14.08%","Clockwork Timespinner",1052
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","12.47%","Dread Knight",1052
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","18.04%","Portal Plunderer",1246
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","13.75%","Dread Knight",1246
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","25.62%","Epoch Golem",1246
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","11.52%","Record Keeper's Assistant",1246
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","2.05%","Harbinger of Death",1246
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","3.30%","Sentient Slime",1246
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","11.34%","Record Keeper",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","18.04%","Portal Plunderer",1246
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","14.37%","Clockwork Timespinner",1246
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","2.90%","Sentient Slime",520
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","1.45%","Harbinger of Death",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","13.75%","Dread Knight",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","11.52%","Record Keeper's Assistant",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","11.34%","Record Keeper",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","3.30%","Sentient Slime",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","2.05%","Harbinger of Death",1246
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","24.22%","Epoch Golem",520
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","17.60%","Portal Plunderer",520
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","15.73%","Clockwork Timespinner",520
@@ -865,329 +863,331 @@
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","11.18%","Dread Knight",520
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","10.35%","Record Keeper's Assistant",520
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","4.97%","Skeletal Champion",520
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","11.83%","Dread Knight",604
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","2.03%","Harbinger of Death",604
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","3.14%","Sentient Slime",604
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","11.28%","Record Keeper's Assistant",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","2.90%","Sentient Slime",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","1.45%","Harbinger of Death",520
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","24.58%","Epoch Golem",604
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","18.48%","Portal Plunderer",604
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","16.45%","Clockwork Timespinner",604
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","12.20%","Record Keeper",604
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","13.60%","Portal Plunderer",591
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","10.95%","Record Keeper's Assistant",591
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","18.20%","Clockwork Timespinner",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","11.83%","Dread Knight",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","11.28%","Record Keeper's Assistant",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","3.14%","Sentient Slime",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","2.03%","Harbinger of Death",604
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","23.85%","Epoch Golem",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","18.20%","Clockwork Timespinner",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","13.60%","Portal Plunderer",591
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","10.95%","Record Keeper",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","10.95%","Record Keeper's Assistant",591
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","10.42%","Dread Knight",591
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","5.30%","Skeletal Champion",591
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","4.24%","Sentient Slime",591
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","2.47%","Harbinger of Death",591
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","11.09%","Dread Knight",727
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","2.55%","Harbinger of Death",727
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","4.50%","Sentient Slime",727
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","10.19%","Record Keeper's Assistant",727
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","12.14%","Record Keeper",727
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","15.44%","Portal Plunderer",727
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","18.74%","Clockwork Timespinner",727
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","25.34%","Epoch Golem",727
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","1.59%","Harbinger of Death",2632
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","10.88%","Dread Knight",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","18.74%","Clockwork Timespinner",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","15.44%","Portal Plunderer",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","12.14%","Record Keeper",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","11.09%","Dread Knight",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","10.19%","Record Keeper's Assistant",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","4.50%","Sentient Slime",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","2.55%","Harbinger of Death",727
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","21.31%","Clockwork Timespinner",2632
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","21.16%","Portal Plunderer",2632
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","11.51%","Record Keeper",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","11.47%","Record Keeper's Assistant",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","10.88%","Dread Knight",2632
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","10.80%","Sentient Slime",2632
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","5.86%","Epoch Golem",2632
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","11.47%","Record Keeper's Assistant",2632
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","5.42%","Skeletal Champion",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","1.59%","Harbinger of Death",2632
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","22.52%","Clockwork Timespinner",3109
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","1.78%","Harbinger of Death",3109
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","6.15%","Epoch Golem",3109
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.28%","Sentient Slime",3109
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.78%","Dread Knight",3109
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.92%","Record Keeper's Assistant",3109
-"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","12.38%","Record Keeper",3109
 "Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","22.20%","Portal Plunderer",3109
-"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","5.88%","Record Keeper's Assistant",405
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","12.38%","Record Keeper",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.92%","Record Keeper's Assistant",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.78%","Dread Knight",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.28%","Sentient Slime",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","6.15%","Epoch Golem",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","1.78%","Harbinger of Death",3109
 "Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","94.12%","Skeletal Champion",405
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","5.88%","Record Keeper's Assistant",405
 "Bristle Woods Rift","Pursuer Mousoleum","Brie String","Rift Antiskele","93.18%","Record Keeper's Assistant",525
 "Bristle Woods Rift","Pursuer Mousoleum","Brie String","Rift Antiskele","6.82%","Record Keeper",525
 "Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","-","94.12%","Skeletal Champion",405
 "Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","-","5.88%","Record Keeper's Assistant",405
-"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","6.82%","Record Keeper",525
 "Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","93.18%","Record Keeper's Assistant",525
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","6.82%","Record Keeper",525
 "Bristle Woods Rift","Runic Laboratory","Runic String","-","29.54%","Timelost Thaumaturge",4637
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","0.32%","Sentient Slime",4637
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","1.84%","Harbinger of Death",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","15.86%","Shackled Servant",4637
 "Bristle Woods Rift","Runic Laboratory","Runic String","-","15.73%","Chamber Cleaver",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","11.45%","Timeslither Pythoness",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","10.24%","Dread Knight",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","6.72%","Vigilant Ward",4637
 "Bristle Woods Rift","Runic Laboratory","Runic String","-","4.34%","Skeletal Champion",4637
 "Bristle Woods Rift","Runic Laboratory","Runic String","-","3.95%","Portal Paladin",4637
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","15.86%","Shackled Servant",4637
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","6.72%","Vigilant Ward",4637
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","10.24%","Dread Knight",4637
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","11.45%","Timeslither Pythoness",4637
-"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","6.97%","Vigilant Ward",4936
-"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","0.38%","Sentient Slime",4936
-"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","10.93%","Dread Knight",4936
-"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","12.03%","Timeslither Pythoness",4936
-"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","16.40%","Shackled Servant",4936
-"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","16.63%","Chamber Cleaver",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","1.84%","Harbinger of Death",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","0.32%","Sentient Slime",4637
 "Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","30.53%","Timelost Thaumaturge",4936
-"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","1.91%","Harbinger of Death",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","16.63%","Chamber Cleaver",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","16.40%","Shackled Servant",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","12.03%","Timeslither Pythoness",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","10.93%","Dread Knight",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","6.97%","Vigilant Ward",4936
 "Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","4.22%","Portal Paladin",4936
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","2.15%","Harbinger of Death",15989
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","5.20%","Skeletal Champion",15989
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","5.47%","Portal Paladin",15989
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","1.91%","Harbinger of Death",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","0.38%","Sentient Slime",4936
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","26.07%","Timelost Thaumaturge",15989
 "Bristle Woods Rift","Runic Laboratory","Ancient String","-","20.93%","Vigilant Ward",15989
 "Bristle Woods Rift","Runic Laboratory","Ancient String","-","20.11%","Shackled Servant",15989
 "Bristle Woods Rift","Runic Laboratory","Ancient String","-","10.57%","Timeslither Pythoness",15989
 "Bristle Woods Rift","Runic Laboratory","Ancient String","-","9.50%","Sentient Slime",15989
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","26.07%","Timelost Thaumaturge",15989
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","10.14%","Sentient Slime",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","5.47%","Portal Paladin",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","5.20%","Skeletal Champion",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","2.15%","Harbinger of Death",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","27.51%","Timelost Thaumaturge",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","22.11%","Vigilant Ward",18104
 "Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","21.12%","Shackled Servant",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","11.09%","Timeslither Pythoness",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","10.14%","Sentient Slime",18104
 "Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","5.69%","Portal Paladin",18104
 "Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","2.33%","Harbinger of Death",18104
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","22.11%","Vigilant Ward",18104
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","27.51%","Timelost Thaumaturge",18104
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","11.09%","Timeslither Pythoness",18104
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","4.07%","Portal Paladin",393
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","1.53%","Timelost Thaumaturge",393
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","3.56%","Harbinger of Death",393
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","6.36%","Skeletal Champion",393
 "Bristle Woods Rift","Runic Laboratory","Magical String","-","40.97%","Sentient Slime",393
 "Bristle Woods Rift","Runic Laboratory","Magical String","-","19.34%","Dread Knight",393
 "Bristle Woods Rift","Runic Laboratory","Magical String","-","16.03%","Shackled Servant",393
 "Bristle Woods Rift","Runic Laboratory","Magical String","-","8.14%","Vigilant Ward",393
-"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","3.23%","Harbinger of Death",491
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","6.36%","Skeletal Champion",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","4.07%","Portal Paladin",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","3.56%","Harbinger of Death",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","1.53%","Timelost Thaumaturge",393
 "Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","41.51%","Sentient Slime",491
 "Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","22.58%","Dread Knight",491
 "Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","17.20%","Shackled Servant",491
 "Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","9.68%","Vigilant Ward",491
-"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","1.29%","Timelost Thaumaturge",491
 "Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","4.52%","Portal Paladin",491
+"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","3.23%","Harbinger of Death",491
+"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","1.29%","Timelost Thaumaturge",491
+"Bristle Woods Rift","Runic Laboratory","Brie String","-","38.88%","Sentient Slime",2246
+"Bristle Woods Rift","Runic Laboratory","Brie String","-","25.25%","Dread Knight",2246
 "Bristle Woods Rift","Runic Laboratory","Brie String","-","14.89%","Vigilant Ward",2246
 "Bristle Woods Rift","Runic Laboratory","Brie String","-","8.79%","Shackled Servant",2246
 "Bristle Woods Rift","Runic Laboratory","Brie String","-","5.16%","Portal Paladin",2246
 "Bristle Woods Rift","Runic Laboratory","Brie String","-","4.98%","Skeletal Champion",2246
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","25.25%","Dread Knight",2246
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","38.88%","Sentient Slime",2246
 "Bristle Woods Rift","Runic Laboratory","Brie String","-","2.06%","Harbinger of Death",2246
 "Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","40.95%","Sentient Slime",2564
-"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","9.48%","Shackled Servant",2564
-"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","15.26%","Vigilant Ward",2564
-"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","2.31%","Harbinger of Death",2564
-"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","6.10%","Portal Paladin",2564
 "Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","25.90%","Dread Knight",2564
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","1.76%","Portal Paladin",170
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","5.29%","Skeletal Champion",170
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","18.24%","Vigilant Ward",170
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","24.12%","Dread Knight",170
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","15.26%","Vigilant Ward",2564
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","9.48%","Shackled Servant",2564
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","6.10%","Portal Paladin",2564
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","2.31%","Harbinger of Death",2564
 "Bristle Woods Rift","Runic Laboratory","Swiss String","-","42.94%","Sentient Slime",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","24.12%","Dread Knight",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","18.24%","Vigilant Ward",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","5.29%","Skeletal Champion",170
 "Bristle Woods Rift","Runic Laboratory","Swiss String","-","4.12%","Shackled Servant",170
 "Bristle Woods Rift","Runic Laboratory","Swiss String","-","3.53%","Harbinger of Death",170
-"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","25.15%","Dread Knight",172
-"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","1.84%","Portal Paladin",172
-"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","3.68%","Harbinger of Death",172
-"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","4.29%","Shackled Servant",172
-"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","19.02%","Vigilant Ward",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","1.76%","Portal Paladin",170
 "Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","46.01%","Sentient Slime",172
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","0.34%","Sentient Slime",4637
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","1.91%","Harbinger of Death",4637
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","7.00%","Vigilant Ward",4637
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","10.66%","Dread Knight",4637
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","4.52%","Skeletal Champion",4637
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","11.92%","Timeslither Pythoness",4637
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","16.38%","Chamber Cleaver",4637
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","16.51%","Shackled Servant",4637
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","25.15%","Dread Knight",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","19.02%","Vigilant Ward",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","4.29%","Shackled Servant",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","3.68%","Harbinger of Death",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","1.84%","Portal Paladin",172
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","30.75%","Timelost Thaumaturge",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","16.51%","Shackled Servant",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","16.38%","Chamber Cleaver",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","11.92%","Timeslither Pythoness",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","10.66%","Dread Knight",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","7.00%","Vigilant Ward",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","4.52%","Skeletal Champion",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","1.91%","Harbinger of Death",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","0.34%","Sentient Slime",4637
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","31.87%","Timelost Thaumaturge",4936
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","0.40%","Sentient Slime",4936
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","1.99%","Harbinger of Death",4936
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","7.28%","Vigilant Ward",4936
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","11.41%","Dread Knight",4936
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","17.36%","Chamber Cleaver",4936
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","17.12%","Shackled Servant",4936
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","12.56%","Timeslither Pythoness",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","11.41%","Dread Knight",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","7.28%","Vigilant Ward",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","1.99%","Harbinger of Death",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","0.40%","Sentient Slime",4936
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","27.58%","Timelost Thaumaturge",15989
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","22.14%","Vigilant Ward",15989
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","21.28%","Shackled Servant",15989
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","11.18%","Timeslither Pythoness",15989
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","5.50%","Skeletal Champion",15989
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","10.05%","Sentient Slime",15989
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","5.50%","Skeletal Champion",15989
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","2.27%","Harbinger of Death",15989
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","29.17%","Timelost Thaumaturge",18104
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","2.48%","Harbinger of Death",18104
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","10.75%","Sentient Slime",18104
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","11.76%","Timeslither Pythoness",18104
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","22.39%","Shackled Servant",18104
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","23.44%","Vigilant Ward",18104
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","6.63%","Skeletal Champion",393
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","8.49%","Vigilant Ward",393
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","16.71%","Shackled Servant",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","22.39%","Shackled Servant",18104
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","11.76%","Timeslither Pythoness",18104
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","10.75%","Sentient Slime",18104
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","2.48%","Harbinger of Death",18104
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","42.71%","Sentient Slime",393
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","20.16%","Dread Knight",393
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","1.59%","Timelost Thaumaturge",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","16.71%","Shackled Servant",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","8.49%","Vigilant Ward",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","6.63%","Skeletal Champion",393
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","3.71%","Harbinger of Death",393
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","23.65%","Dread Knight",491
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","1.35%","Timelost Thaumaturge",491
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","3.38%","Harbinger of Death",491
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","10.14%","Vigilant Ward",491
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","18.02%","Shackled Servant",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","1.59%","Timelost Thaumaturge",393
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","43.47%","Sentient Slime",491
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","9.27%","Shackled Servant",2246
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","5.25%","Skeletal Champion",2246
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","2.17%","Harbinger of Death",2246
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","23.65%","Dread Knight",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","18.02%","Shackled Servant",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","10.14%","Vigilant Ward",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","3.38%","Harbinger of Death",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","1.35%","Timelost Thaumaturge",491
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","40.99%","Sentient Slime",2246
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","26.62%","Dread Knight",2246
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","15.70%","Vigilant Ward",2246
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","10.10%","Shackled Servant",2564
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","2.46%","Harbinger of Death",2564
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","9.27%","Shackled Servant",2246
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","5.25%","Skeletal Champion",2246
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","2.17%","Harbinger of Death",2246
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","43.61%","Sentient Slime",2564
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","27.58%","Dread Knight",2564
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","16.25%","Vigilant Ward",2564
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","3.59%","Harbinger of Death",170
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","10.10%","Shackled Servant",2564
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","2.46%","Harbinger of Death",2564
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","43.71%","Sentient Slime",170
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","24.55%","Dread Knight",170
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","18.56%","Vigilant Ward",170
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","5.39%","Skeletal Champion",170
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","4.19%","Shackled Servant",170
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","24.55%","Dread Knight",170
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","25.62%","Dread Knight",172
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","3.75%","Harbinger of Death",172
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","4.38%","Shackled Servant",172
-"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","19.38%","Vigilant Ward",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","3.59%","Harbinger of Death",170
 "Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","46.88%","Sentient Slime",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","25.62%","Dread Knight",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","19.38%","Vigilant Ward",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","4.38%","Shackled Servant",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","3.75%","Harbinger of Death",172
 "Bristle Woods Rift","Security","Runic String","-","91.70%","Skeletal Champion",255
 "Bristle Woods Rift","Security","Runic String","-","7.11%","Timelost Thaumaturge",255
 "Bristle Woods Rift","Security","Runic String","-","0.79%","Shackled Servant",255
 "Bristle Woods Rift","Security","Runic String","-","0.40%","Vigilant Ward",255
-"Bristle Woods Rift","Security","Runic String","Rift Antiskele","19.35%","Shackled Servant",269
 "Bristle Woods Rift","Security","Runic String","Rift Antiskele","77.42%","Timelost Thaumaturge",269
+"Bristle Woods Rift","Security","Runic String","Rift Antiskele","19.35%","Shackled Servant",269
 "Bristle Woods Rift","Security","Runic String","Rift Antiskele","3.23%","Vigilant Ward",269
-"Bristle Woods Rift","Security","Ancient String","-","1.68%","Shackled Servant",179
-"Bristle Woods Rift","Security","Ancient String","-","1.12%","Vigilant Ward",179
 "Bristle Woods Rift","Security","Ancient String","-","91.06%","Skeletal Champion",179
 "Bristle Woods Rift","Security","Ancient String","-","6.15%","Timelost Thaumaturge",179
+"Bristle Woods Rift","Security","Ancient String","-","1.68%","Shackled Servant",179
+"Bristle Woods Rift","Security","Ancient String","-","1.12%","Vigilant Ward",179
+"Bristle Woods Rift","Security","Ancient String","Rift Antiskele","62.07%","Timelost Thaumaturge",208
 "Bristle Woods Rift","Security","Ancient String","Rift Antiskele","24.14%","Shackled Servant",208
 "Bristle Woods Rift","Security","Ancient String","Rift Antiskele","13.79%","Vigilant Ward",208
-"Bristle Woods Rift","Security","Ancient String","Rift Antiskele","62.07%","Timelost Thaumaturge",208
-"Bristle Woods Rift","Security","Magical String","-","5.83%","Timelost Thaumaturge",120
 "Bristle Woods Rift","Security","Magical String","-","91.67%","Skeletal Champion",120
+"Bristle Woods Rift","Security","Magical String","-","5.83%","Timelost Thaumaturge",120
 "Bristle Woods Rift","Security","Magical String","-","1.67%","Vigilant Ward",120
 "Bristle Woods Rift","Security","Magical String","-","0.83%","Shackled Servant",120
-"Bristle Woods Rift","Security","Magical String","Rift Antiskele","17.65%","Vigilant Ward",144
 "Bristle Woods Rift","Security","Magical String","Rift Antiskele","76.47%","Timelost Thaumaturge",144
+"Bristle Woods Rift","Security","Magical String","Rift Antiskele","17.65%","Vigilant Ward",144
 "Bristle Woods Rift","Security","Magical String","Rift Antiskele","5.88%","Shackled Servant",144
-"Bristle Woods Rift","Security","Brie String","-","4.21%","Vigilant Ward",913
-"Bristle Woods Rift","Security","Brie String","-","1.88%","Shackled Servant",913
 "Bristle Woods Rift","Security","Brie String","-","90.58%","Skeletal Champion",913
+"Bristle Woods Rift","Security","Brie String","-","4.21%","Vigilant Ward",913
 "Bristle Woods Rift","Security","Brie String","-","3.33%","Timelost Thaumaturge",913
+"Bristle Woods Rift","Security","Brie String","-","1.88%","Shackled Servant",913
+"Bristle Woods Rift","Security","Brie String","Rift Antiskele","41.33%","Timelost Thaumaturge",1170
 "Bristle Woods Rift","Security","Brie String","Rift Antiskele","37.76%","Vigilant Ward",1170
 "Bristle Woods Rift","Security","Brie String","Rift Antiskele","20.92%","Shackled Servant",1170
-"Bristle Woods Rift","Security","Brie String","Rift Antiskele","41.33%","Timelost Thaumaturge",1170
-"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","0.40%","Vigilant Ward",255
-"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","0.79%","Shackled Servant",255
-"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","7.11%","Timelost Thaumaturge",255
 "Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","91.70%","Skeletal Champion",255
-"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","Rift Antiskele","3.23%","Vigilant Ward",269
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","7.11%","Timelost Thaumaturge",255
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","0.79%","Shackled Servant",255
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","0.40%","Vigilant Ward",255
 "Bristle Woods Rift","Security (Paladin's Bane)","Runic String","Rift Antiskele","77.42%","Timelost Thaumaturge",269
 "Bristle Woods Rift","Security (Paladin's Bane)","Runic String","Rift Antiskele","19.35%","Shackled Servant",269
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","Rift Antiskele","3.23%","Vigilant Ward",269
 "Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","-","91.06%","Skeletal Champion",179
-"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","-","1.68%","Shackled Servant",179
 "Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","-","6.15%","Timelost Thaumaturge",179
+"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","-","1.68%","Shackled Servant",179
 "Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","-","1.12%","Vigilant Ward",179
-"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","Rift Antiskele","24.14%","Shackled Servant",208
 "Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","Rift Antiskele","62.07%","Timelost Thaumaturge",208
+"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","Rift Antiskele","24.14%","Shackled Servant",208
 "Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","Rift Antiskele","13.79%","Vigilant Ward",208
+"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","91.67%","Skeletal Champion",120
+"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","5.83%","Timelost Thaumaturge",120
 "Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","1.67%","Vigilant Ward",120
 "Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","0.83%","Shackled Servant",120
-"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","5.83%","Timelost Thaumaturge",120
-"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","91.67%","Skeletal Champion",120
 "Bristle Woods Rift","Security (Paladin's Bane)","Magical String","Rift Antiskele","76.47%","Timelost Thaumaturge",144
 "Bristle Woods Rift","Security (Paladin's Bane)","Magical String","Rift Antiskele","17.65%","Vigilant Ward",144
 "Bristle Woods Rift","Security (Paladin's Bane)","Magical String","Rift Antiskele","5.88%","Shackled Servant",144
+"Bristle Woods Rift","Security (Paladin's Bane)","Brie String","-","90.58%","Skeletal Champion",913
 "Bristle Woods Rift","Security (Paladin's Bane)","Brie String","-","4.21%","Vigilant Ward",913
 "Bristle Woods Rift","Security (Paladin's Bane)","Brie String","-","3.33%","Timelost Thaumaturge",913
 "Bristle Woods Rift","Security (Paladin's Bane)","Brie String","-","1.88%","Shackled Servant",913
-"Bristle Woods Rift","Security (Paladin's Bane)","Brie String","-","90.58%","Skeletal Champion",913
 "Bristle Woods Rift","Security (Paladin's Bane)","Brie String","Rift Antiskele","41.33%","Timelost Thaumaturge",1170
 "Bristle Woods Rift","Security (Paladin's Bane)","Brie String","Rift Antiskele","37.76%","Vigilant Ward",1170
 "Bristle Woods Rift","Security (Paladin's Bane)","Brie String","Rift Antiskele","20.92%","Shackled Servant",1170
 "Bristle Woods Rift","Timewarp","Runic String","-","33.83%","Carrion Medium",36410
-"Bristle Woods Rift","Timewarp","Runic String","-","5.36%","Skeletal Champion",36410
+"Bristle Woods Rift","Timewarp","Runic String","-","26.26%","Chronomaster",36410
 "Bristle Woods Rift","Timewarp","Runic String","-","19.17%","Timeless Lich",36410
 "Bristle Woods Rift","Timewarp","Runic String","-","10.24%","Sentient Slime",36410
-"Bristle Woods Rift","Timewarp","Runic String","-","26.26%","Chronomaster",36410
+"Bristle Woods Rift","Timewarp","Runic String","-","5.36%","Skeletal Champion",36410
 "Bristle Woods Rift","Timewarp","Runic String","-","5.15%","Portal Paladin",36410
+"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","35.77%","Carrion Medium",43160
+"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","27.71%","Chronomaster",43160
 "Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","20.18%","Timeless Lich",43160
 "Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","10.92%","Sentient Slime",43160
-"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","27.71%","Chronomaster",43160
-"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","35.77%","Carrion Medium",43160
 "Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","5.42%","Portal Paladin",43160
-"Bristle Woods Rift","Timewarp","Ancient String","-","15.82%","Timeless Lich",792
-"Bristle Woods Rift","Timewarp","Ancient String","-","5.87%","Skeletal Champion",792
-"Bristle Woods Rift","Timewarp","Ancient String","-","4.97%","Portal Paladin",792
 "Bristle Woods Rift","Timewarp","Ancient String","-","30.48%","Dread Knight",792
 "Bristle Woods Rift","Timewarp","Ancient String","-","26.28%","Sentient Slime",792
 "Bristle Woods Rift","Timewarp","Ancient String","-","16.58%","Carrion Medium",792
-"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","17.45%","Timeless Lich",906
-"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","5.66%","Portal Paladin",906
-"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","17.33%","Carrion Medium",906
+"Bristle Woods Rift","Timewarp","Ancient String","-","15.82%","Timeless Lich",792
+"Bristle Woods Rift","Timewarp","Ancient String","-","5.87%","Skeletal Champion",792
+"Bristle Woods Rift","Timewarp","Ancient String","-","4.97%","Portal Paladin",792
 "Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","32.08%","Dread Knight",906
 "Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","27.48%","Sentient Slime",906
+"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","17.45%","Timeless Lich",906
+"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","17.33%","Carrion Medium",906
+"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","5.66%","Portal Paladin",906
+"Bristle Woods Rift","Timewarp","Magical String","-","40.41%","Sentient Slime",344
+"Bristle Woods Rift","Timewarp","Magical String","-","33.72%","Dread Knight",344
 "Bristle Woods Rift","Timewarp","Magical String","-","11.05%","Carrion Medium",344
 "Bristle Woods Rift","Timewarp","Magical String","-","6.40%","Skeletal Champion",344
-"Bristle Woods Rift","Timewarp","Magical String","-","33.72%","Dread Knight",344
-"Bristle Woods Rift","Timewarp","Magical String","-","40.41%","Sentient Slime",344
 "Bristle Woods Rift","Timewarp","Magical String","-","4.94%","Portal Paladin",344
 "Bristle Woods Rift","Timewarp","Magical String","-","3.49%","Timeless Lich",344
-"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","3.76%","Timeless Lich",369
-"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","5.20%","Portal Paladin",369
-"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","12.14%","Carrion Medium",369
 "Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","42.49%","Sentient Slime",369
 "Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","36.42%","Dread Knight",369
+"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","12.14%","Carrion Medium",369
+"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","5.20%","Portal Paladin",369
+"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","3.76%","Timeless Lich",369
 "Bristle Woods Rift","Timewarp","Brie String","-","41.16%","Dread Knight",1743
-"Bristle Woods Rift","Timewarp","Brie String","-","8.03%","Carrion Medium",1743
-"Bristle Woods Rift","Timewarp","Brie String","-","2.20%","Timeless Lich",1743
-"Bristle Woods Rift","Timewarp","Brie String","-","4.22%","Portal Paladin",1743
 "Bristle Woods Rift","Timewarp","Brie String","-","38.21%","Sentient Slime",1743
+"Bristle Woods Rift","Timewarp","Brie String","-","8.03%","Carrion Medium",1743
 "Bristle Woods Rift","Timewarp","Brie String","-","6.18%","Skeletal Champion",1743
-"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","8.45%","Carrion Medium",1929
-"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","41.13%","Sentient Slime",1929
+"Bristle Woods Rift","Timewarp","Brie String","-","4.22%","Portal Paladin",1743
+"Bristle Woods Rift","Timewarp","Brie String","-","2.20%","Timeless Lich",1743
 "Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","43.41%","Dread Knight",1929
-"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","2.33%","Timeless Lich",1929
+"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","41.13%","Sentient Slime",1929
+"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","8.45%","Carrion Medium",1929
 "Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","4.67%","Portal Paladin",1929
+"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","2.33%","Timeless Lich",1929
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","35.66%","Carrion Medium",36410
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","27.68%","Chronomaster",36410
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","20.21%","Timeless Lich",36410
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","10.79%","Sentient Slime",36410
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","5.65%","Skeletal Champion",36410
-"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","35.66%","Carrion Medium",36410
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","Rift Antiskele","37.82%","Carrion Medium",43160
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","Rift Antiskele","29.30%","Chronomaster",43160
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","Rift Antiskele","21.33%","Timeless Lich",43160
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","Rift Antiskele","11.54%","Sentient Slime",43160
-"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","Rift Antiskele","29.30%","Chronomaster",43160
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","32.08%","Dread Knight",792
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","27.65%","Sentient Slime",792
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","17.45%","Carrion Medium",792
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","16.64%","Timeless Lich",792
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","6.17%","Skeletal Champion",792
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","Rift Antiskele","34.00%","Dread Knight",906
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","Rift Antiskele","29.13%","Sentient Slime",906
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","Rift Antiskele","18.50%","Timeless Lich",906
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","Rift Antiskele","18.38%","Carrion Medium",906
-"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","Rift Antiskele","34.00%","Dread Knight",906
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","42.51%","Sentient Slime",344
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","35.47%","Dread Knight",344
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","11.62%","Carrion Medium",344
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","6.73%","Skeletal Champion",344
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","3.67%","Timeless Lich",344
-"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","42.51%","Sentient Slime",344
-"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","11.62%","Carrion Medium",344
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","Rift Antiskele","44.82%","Sentient Slime",369
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","Rift Antiskele","38.41%","Dread Knight",369
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","Rift Antiskele","12.80%","Carrion Medium",369
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","Rift Antiskele","3.96%","Timeless Lich",369
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","42.97%","Dread Knight",1743
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","39.89%","Sentient Slime",1743
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","8.39%","Carrion Medium",1743
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","6.46%","Skeletal Champion",1743
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","2.29%","Timeless Lich",1743
-"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","42.97%","Dread Knight",1743
-"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","8.86%","Carrion Medium",1929
-"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","2.45%","Timeless Lich",1929
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","45.54%","Dread Knight",1929
 "Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","43.15%","Sentient Slime",1929
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","8.86%","Carrion Medium",1929
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","2.45%","Timeless Lich",1929

--- a/data/pop-bwrift.csv
+++ b/data/pop-bwrift.csv
@@ -1,411 +1,1193 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Bristle Woods Rift","Acolyte","Runic String","-","23.78%","Dread Knight",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","23.13%","Skeletal Champion",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","8.84%","Vigilant Ward",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","8.59%","Absolute Acolyte",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","8.21%","Portal Paladin",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","6.09%","Timelost Thaumaturge",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","5.30%","Timeslither Pythoness",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","5.20%","Shackled Servant",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","3.79%","Carrion Medium",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","3.69%","Harbinger of Death",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","2.59%","Timeless Lich",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","0.56%","Chronomaster",32805
-"Bristle Woods Rift","Acolyte","Runic String","-","0.23%","Portal Pursuer",32805
-"Bristle Woods Rift","Ancient Lab","Runic String","-","33.51%","Epoch Golem",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","26.18%","Chamber Cleaver",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","14.26%","Portal Plunderer",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","12.46%","Dread Knight",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","5.46%","Skeletal Champion",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","3.06%","Portal Paladin",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","1.93%","Clockwork Timespinner",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","1.33%","Record Keeper",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","1.00%","Record Keeper's Assistant",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","0.60%","Sentient Slime",1501
-"Bristle Woods Rift","Ancient Lab","Runic String","-","0.20%","Portal Pursuer",1501
-"Bristle Woods Rift","Entrance","Runic String","-","77.91%","Vigilant Ward",172
-"Bristle Woods Rift","Entrance","Runic String","-","10.47%","Portal Paladin",172
-"Bristle Woods Rift","Entrance","Runic String","-","4.65%","Portal Plunderer",172
-"Bristle Woods Rift","Entrance","Runic String","-","2.91%","Epoch Golem",172
-"Bristle Woods Rift","Entrance","Runic String","-","2.91%","Skeletal Champion",172
-"Bristle Woods Rift","Entrance","Runic String","-","1.16%","Clockwork Timespinner",172
-"Bristle Woods Rift","Frozen Alcove","Runic String","-","54.98%","Sentient Slime",2643
-"Bristle Woods Rift","Frozen Alcove","Runic String","-","38.18%","Dread Knight",2643
-"Bristle Woods Rift","Frozen Alcove","Runic String","-","6.13%","Portal Paladin",2643
-"Bristle Woods Rift","Frozen Alcove","Runic String","-","0.57%","Harbinger of Death",2643
-"Bristle Woods Rift","Frozen Alcove","Runic String","-","0.15%","Portal Pursuer",2643
-"Bristle Woods Rift","Gearworks","Runic String","-","37.33%","Dread Knight",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","26.35%","Chamber Cleaver",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","10.65%","Portal Plunderer",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","9.25%","Skeletal Champion",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","5.46%","Portal Paladin",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","3.86%","Clockwork Timespinner",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","3.26%","Sentient Slime",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","1.93%","Record Keeper",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","1.00%","Record Keeper's Assistant",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","0.40%","Timelost Thaumaturge",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","0.27%","Portal Pursuer",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","0.13%","Vigilant Ward",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","0.07%","Harbinger of Death",1503
-"Bristle Woods Rift","Gearworks","Runic String","-","0.07%","Shackled Servant",1503
-"Bristle Woods Rift","Guard Barracks","Runic String","-","66.09%","Portal Paladin",4123
-"Bristle Woods Rift","Guard Barracks","Runic String","-","17.46%","Dread Knight",4123
-"Bristle Woods Rift","Guard Barracks","Runic String","-","13.39%","Epoch Golem",4123
-"Bristle Woods Rift","Guard Barracks","Runic String","-","1.92%","Clockwork Timespinner",4123
-"Bristle Woods Rift","Guard Barracks","Runic String","-","1.07%","Sentient Slime",4123
-"Bristle Woods Rift","Guard Barracks","Runic String","-","0.07%","Portal Pursuer",4123
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","27.03%","Timeless Lich",481
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","27.03%","Timeslither Pythoness",481
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","11.02%","Portal Plunderer",481
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","9.98%","Epoch Golem",481
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","5.61%","Shackled Servant",481
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","5.20%","Dread Knight",481
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.78%","Portal Paladin",481
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","3.74%","Skeletal Champion",481
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","3.12%","Carrion Medium",481
-"Bristle Woods Rift","Hidden Treasury","Runic String","-","2.49%","Harbinger of Death",481
-"Bristle Woods Rift","Ingress","Runic String","-","20.55%","Sentient Slime",1455
-"Bristle Woods Rift","Ingress","Runic String","-","20.00%","Portal Pursuer",1455
-"Bristle Woods Rift","Ingress","Runic String","-","19.31%","Dread Knight",1455
-"Bristle Woods Rift","Ingress","Runic String","-","19.18%","Clockwork Timespinner",1455
-"Bristle Woods Rift","Ingress","Runic String","-","11.13%","Vigilant Ward",1455
-"Bristle Woods Rift","Ingress","Runic String","-","8.66%","Shackled Servant",1455
-"Bristle Woods Rift","Ingress","Runic String","-","1.17%","Harbinger of Death",1455
-"Bristle Woods Rift","Lucky Tower","Runic String","-","24.84%","Epoch Golem",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","14.68%","Portal Plunderer",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","12.90%","Clockwork Timespinner",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","10.97%","Dread Knight",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","10.65%","Record Keeper",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","10.65%","Record Keeper's Assistant",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","5.65%","Skeletal Champion",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","4.19%","Portal Paladin",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","3.23%","Sentient Slime",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","2.10%","Harbinger of Death",620
-"Bristle Woods Rift","Lucky Tower","Runic String","-","0.16%","Portal Pursuer",620
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","29.52%","Timelost Thaumaturge",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","15.49%","Chamber Cleaver",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","15.30%","Shackled Servant",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","11.84%","Timeslither Pythoness",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","10.69%","Dread Knight",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","6.50%","Vigilant Ward",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","4.25%","Skeletal Champion",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","3.97%","Portal Paladin",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","1.86%","Harbinger of Death",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","0.36%","Sentient Slime",3648
-"Bristle Woods Rift","Runic Laboratory","Runic String","-","0.22%","Portal Pursuer",3648
-"Bristle Woods Rift","Security","Runic String","-","90.30%","Skeletal Champion",165
-"Bristle Woods Rift","Security","Runic String","-","7.88%","Timelost Thaumaturge",165
-"Bristle Woods Rift","Security","Runic String","-","1.21%","Portal Pursuer",165
-"Bristle Woods Rift","Security","Runic String","-","0.61%","Shackled Servant",165
-"Bristle Woods Rift","Timewarp","Runic String","-","33.74%","Carrion Medium",24494
-"Bristle Woods Rift","Timewarp","Runic String","-","26.39%","Chronomaster",24494
-"Bristle Woods Rift","Timewarp","Runic String","-","18.96%","Timeless Lich",24494
-"Bristle Woods Rift","Timewarp","Runic String","-","9.90%","Sentient Slime",24494
-"Bristle Woods Rift","Timewarp","Runic String","-","5.41%","Skeletal Champion",24494
-"Bristle Woods Rift","Timewarp","Runic String","-","5.17%","Portal Paladin",24494
-"Bristle Woods Rift","Timewarp","Runic String","-","0.41%","Portal Pursuer",24494
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","45.20%","Epoch Golem",843
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","22.42%","Portal Plunderer",843
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","9.13%","Dread Knight",843
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","5.58%","Portal Paladin",843
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","5.34%","Skeletal Champion",843
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","4.63%","Record Keeper",843
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","4.63%","Clockwork Timespinner",843
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","1.30%","Record Keeper's Assistant",843
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","1.07%","Sentient Slime",843
-"Bristle Woods Rift","Ancient Lab","Ancient String","-","0.71%","Portal Pursuer",843
-"Bristle Woods Rift","Frozen Alcove","Ancient String","-","54.81%","Sentient Slime",810
-"Bristle Woods Rift","Frozen Alcove","Ancient String","-","36.30%","Dread Knight",810
-"Bristle Woods Rift","Frozen Alcove","Ancient String","-","8.15%","Portal Paladin",810
-"Bristle Woods Rift","Frozen Alcove","Ancient String","-","0.62%","Portal Pursuer",810
-"Bristle Woods Rift","Frozen Alcove","Ancient String","-","0.12%","Harbinger of Death",810
-"Bristle Woods Rift","Gearworks","Ancient String","-","37.09%","Dread Knight",337
-"Bristle Woods Rift","Gearworks","Ancient String","-","14.54%","Portal Plunderer",337
-"Bristle Woods Rift","Gearworks","Ancient String","-","9.50%","Sentient Slime",337
-"Bristle Woods Rift","Gearworks","Ancient String","-","9.50%","Record Keeper's Assistant",337
-"Bristle Woods Rift","Gearworks","Ancient String","-","9.50%","Clockwork Timespinner",337
-"Bristle Woods Rift","Gearworks","Ancient String","-","6.53%","Record Keeper",337
-"Bristle Woods Rift","Gearworks","Ancient String","-","6.53%","Skeletal Champion",337
-"Bristle Woods Rift","Gearworks","Ancient String","-","4.75%","Portal Paladin",337
-"Bristle Woods Rift","Gearworks","Ancient String","-","2.08%","Portal Pursuer",337
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","57.33%","Portal Paladin",1249
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","14.97%","Dread Knight",1249
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","12.01%","Sentient Slime",1249
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","9.29%","Epoch Golem",1249
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","5.84%","Clockwork Timespinner",1249
-"Bristle Woods Rift","Guard Barracks","Ancient String","-","0.56%","Portal Pursuer",1249
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","25.65%","Timeslither Pythoness",191
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","17.28%","Epoch Golem",191
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","16.75%","Timeless Lich",191
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","14.66%","Portal Plunderer",191
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","6.81%","Portal Paladin",191
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","5.76%","Dread Knight",191
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","4.19%","Carrion Medium",191
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","3.66%","Skeletal Champion",191
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","3.66%","Shackled Servant",191
-"Bristle Woods Rift","Hidden Treasury","Ancient String","-","1.57%","Harbinger of Death",191
-"Bristle Woods Rift","Ingress","Ancient String","-","25.55%","Portal Pursuer",497
-"Bristle Woods Rift","Ingress","Ancient String","-","19.72%","Clockwork Timespinner",497
-"Bristle Woods Rift","Ingress","Ancient String","-","15.09%","Dread Knight",497
-"Bristle Woods Rift","Ingress","Ancient String","-","15.09%","Sentient Slime",497
-"Bristle Woods Rift","Ingress","Ancient String","-","12.07%","Vigilant Ward",497
-"Bristle Woods Rift","Ingress","Ancient String","-","11.47%","Shackled Servant",497
-"Bristle Woods Rift","Ingress","Ancient String","-","1.01%","Harbinger of Death",497
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","26.27%","Epoch Golem",316
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","17.09%","Portal Plunderer",316
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","14.87%","Clockwork Timespinner",316
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","9.49%","Dread Knight",316
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","8.23%","Record Keeper",316
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","7.91%","Portal Paladin",316
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","6.96%","Record Keeper's Assistant",316
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","3.80%","Sentient Slime",316
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","3.80%","Skeletal Champion",316
-"Bristle Woods Rift","Lucky Tower","Ancient String","-","1.58%","Harbinger of Death",316
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","25.94%","Timelost Thaumaturge",12200
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","20.89%","Vigilant Ward",12200
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","20.18%","Shackled Servant",12200
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","10.40%","Timeslither Pythoness",12200
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","9.54%","Sentient Slime",12200
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","5.53%","Portal Paladin",12200
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","4.96%","Skeletal Champion",12200
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","2.18%","Harbinger of Death",12200
-"Bristle Woods Rift","Runic Laboratory","Ancient String","-","0.37%","Portal Pursuer",12200
-"Bristle Woods Rift","Security","Ancient String","-","89.31%","Skeletal Champion",131
-"Bristle Woods Rift","Security","Ancient String","-","7.63%","Timelost Thaumaturge",131
-"Bristle Woods Rift","Security","Ancient String","-","1.53%","Vigilant Ward",131
-"Bristle Woods Rift","Security","Ancient String","-","1.53%","Shackled Servant",131
-"Bristle Woods Rift","Timewarp","Ancient String","-","30.66%","Dread Knight",499
-"Bristle Woods Rift","Timewarp","Ancient String","-","28.46%","Sentient Slime",499
-"Bristle Woods Rift","Timewarp","Ancient String","-","14.83%","Carrion Medium",499
-"Bristle Woods Rift","Timewarp","Ancient String","-","14.43%","Timeless Lich",499
-"Bristle Woods Rift","Timewarp","Ancient String","-","6.21%","Skeletal Champion",499
-"Bristle Woods Rift","Timewarp","Ancient String","-","4.01%","Portal Paladin",499
-"Bristle Woods Rift","Timewarp","Ancient String","-","1.40%","Portal Pursuer",499
-"Bristle Woods Rift","Ancient Lab","Magical String","-","39.93%","Epoch Golem",2945
-"Bristle Woods Rift","Ancient Lab","Magical String","-","21.22%","Portal Plunderer",2945
-"Bristle Woods Rift","Ancient Lab","Magical String","-","13.21%","Clockwork Timespinner",2945
-"Bristle Woods Rift","Ancient Lab","Magical String","-","5.64%","Portal Paladin",2945
-"Bristle Woods Rift","Ancient Lab","Magical String","-","5.30%","Record Keeper's Assistant",2945
-"Bristle Woods Rift","Ancient Lab","Magical String","-","4.92%","Record Keeper",2945
-"Bristle Woods Rift","Ancient Lab","Magical String","-","4.92%","Sentient Slime",2945
-"Bristle Woods Rift","Ancient Lab","Magical String","-","4.86%","Skeletal Champion",2945
-"Bristle Woods Rift","Frozen Alcove","Magical String","-","80.65%","Sentient Slime",1008
-"Bristle Woods Rift","Frozen Alcove","Magical String","-","10.91%","Dread Knight",1008
-"Bristle Woods Rift","Frozen Alcove","Magical String","-","8.43%","Portal Paladin",1008
-"Bristle Woods Rift","Gearworks","Magical String","-","20.07%","Record Keeper's Assistant",1525
-"Bristle Woods Rift","Gearworks","Magical String","-","17.77%","Record Keeper",1525
-"Bristle Woods Rift","Gearworks","Magical String","-","16.72%","Dread Knight",1525
-"Bristle Woods Rift","Gearworks","Magical String","-","14.82%","Sentient Slime",1525
-"Bristle Woods Rift","Gearworks","Magical String","-","9.51%","Skeletal Champion",1525
-"Bristle Woods Rift","Gearworks","Magical String","-","8.46%","Portal Paladin",1525
-"Bristle Woods Rift","Gearworks","Magical String","-","4.79%","Clockwork Timespinner",1525
-"Bristle Woods Rift","Gearworks","Magical String","-","4.00%","Epoch Golem",1525
-"Bristle Woods Rift","Gearworks","Magical String","-","3.87%","Portal Plunderer",1525
-"Bristle Woods Rift","Guard Barracks","Magical String","-","45.72%","Portal Paladin",1356
-"Bristle Woods Rift","Guard Barracks","Magical String","-","17.26%","Sentient Slime",1356
-"Bristle Woods Rift","Guard Barracks","Magical String","-","14.45%","Clockwork Timespinner",1356
-"Bristle Woods Rift","Guard Barracks","Magical String","-","12.32%","Epoch Golem",1356
-"Bristle Woods Rift","Guard Barracks","Magical String","-","10.25%","Dread Knight",1356
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","35.33%","Epoch Golem",300
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","13.00%","Timeless Lich",300
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","11.67%","Timeslither Pythoness",300
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","11.00%","Portal Plunderer",300
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","6.67%","Skeletal Champion",300
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","6.33%","Portal Paladin",300
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","6.33%","Dread Knight",300
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","4.33%","Carrion Medium",300
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","3.67%","Shackled Servant",300
-"Bristle Woods Rift","Hidden Treasury","Magical String","-","1.67%","Harbinger of Death",300
-"Bristle Woods Rift","Ingress","Magical String","-","38.48%","Portal Pursuer",330
-"Bristle Woods Rift","Ingress","Magical String","-","20.00%","Clockwork Timespinner",330
-"Bristle Woods Rift","Ingress","Magical String","-","19.70%","Sentient Slime",330
-"Bristle Woods Rift","Ingress","Magical String","-","9.39%","Shackled Servant",330
-"Bristle Woods Rift","Ingress","Magical String","-","7.88%","Vigilant Ward",330
-"Bristle Woods Rift","Ingress","Magical String","-","3.64%","Dread Knight",330
-"Bristle Woods Rift","Ingress","Magical String","-","0.91%","Harbinger of Death",330
-"Bristle Woods Rift","Lucky Tower","Magical String","-","23.40%","Epoch Golem",483
-"Bristle Woods Rift","Lucky Tower","Magical String","-","17.18%","Clockwork Timespinner",483
-"Bristle Woods Rift","Lucky Tower","Magical String","-","12.63%","Portal Plunderer",483
-"Bristle Woods Rift","Lucky Tower","Magical String","-","10.97%","Record Keeper's Assistant",483
-"Bristle Woods Rift","Lucky Tower","Magical String","-","10.35%","Record Keeper",483
-"Bristle Woods Rift","Lucky Tower","Magical String","-","9.94%","Dread Knight",483
-"Bristle Woods Rift","Lucky Tower","Magical String","-","4.97%","Skeletal Champion",483
-"Bristle Woods Rift","Lucky Tower","Magical String","-","4.35%","Sentient Slime",483
-"Bristle Woods Rift","Lucky Tower","Magical String","-","4.14%","Portal Paladin",483
-"Bristle Woods Rift","Lucky Tower","Magical String","-","2.07%","Harbinger of Death",483
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","41.16%","Sentient Slime",311
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","18.33%","Dread Knight",311
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","16.40%","Shackled Servant",311
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","7.07%","Skeletal Champion",311
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","7.07%","Vigilant Ward",311
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","4.18%","Portal Paladin",311
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","4.18%","Harbinger of Death",311
-"Bristle Woods Rift","Runic Laboratory","Magical String","-","1.61%","Timelost Thaumaturge",311
-"Bristle Woods Rift","Timewarp","Magical String","-","42.42%","Sentient Slime",264
-"Bristle Woods Rift","Timewarp","Magical String","-","32.20%","Dread Knight",264
-"Bristle Woods Rift","Timewarp","Magical String","-","11.36%","Carrion Medium",264
-"Bristle Woods Rift","Timewarp","Magical String","-","5.68%","Skeletal Champion",264
-"Bristle Woods Rift","Timewarp","Magical String","-","4.55%","Portal Paladin",264
-"Bristle Woods Rift","Timewarp","Magical String","-","3.79%","Timeless Lich",264
-"Bristle Woods Rift","Ancient Lab","Brie String","-","40.66%","Clockwork Timespinner",30156
-"Bristle Woods Rift","Ancient Lab","Brie String","-","37.12%","Portal Plunderer",30156
-"Bristle Woods Rift","Ancient Lab","Brie String","-","5.29%","Skeletal Champion",30156
-"Bristle Woods Rift","Ancient Lab","Brie String","-","5.11%","Record Keeper",30156
-"Bristle Woods Rift","Ancient Lab","Brie String","-","5.09%","Portal Paladin",30156
-"Bristle Woods Rift","Ancient Lab","Brie String","-","4.25%","Epoch Golem",30156
-"Bristle Woods Rift","Ancient Lab","Brie String","-","1.05%","Dread Knight",30156
-"Bristle Woods Rift","Ancient Lab","Brie String","-","0.52%","Sentient Slime",30156
-"Bristle Woods Rift","Ancient Lab","Brie String","-","0.46%","Record Keeper's Assistant",30156
-"Bristle Woods Rift","Ancient Lab","Brie String","-","0.44%","Portal Pursuer",30156
-"Bristle Woods Rift","Frozen Alcove","Brie String","-","81.45%","Sentient Slime",884
-"Bristle Woods Rift","Frozen Alcove","Brie String","-","10.18%","Dread Knight",884
-"Bristle Woods Rift","Frozen Alcove","Brie String","-","6.56%","Portal Paladin",884
-"Bristle Woods Rift","Frozen Alcove","Brie String","-","1.81%","Portal Pursuer",884
-"Bristle Woods Rift","Furnace Room","Brie String","-","88.83%","Skeletal Champion",197
-"Bristle Woods Rift","Furnace Room","Brie String","-","3.55%","Portal Paladin",197
-"Bristle Woods Rift","Furnace Room","Brie String","-","2.03%","Portal Plunderer",197
-"Bristle Woods Rift","Furnace Room","Brie String","-","2.03%","Portal Pursuer",197
-"Bristle Woods Rift","Furnace Room","Brie String","-","2.03%","Clockwork Timespinner",197
-"Bristle Woods Rift","Furnace Room","Brie String","-","1.52%","Dread Knight",197
-"Bristle Woods Rift","Gearworks","Brie String","-","22.92%","Record Keeper's Assistant",9020
-"Bristle Woods Rift","Gearworks","Brie String","-","16.47%","Dread Knight",9020
-"Bristle Woods Rift","Gearworks","Brie String","-","15.02%","Record Keeper",9020
-"Bristle Woods Rift","Gearworks","Brie String","-","13.23%","Sentient Slime",9020
-"Bristle Woods Rift","Gearworks","Brie String","-","11.69%","Skeletal Champion",9020
-"Bristle Woods Rift","Gearworks","Brie String","-","7.72%","Clockwork Timespinner",9020
-"Bristle Woods Rift","Gearworks","Brie String","-","7.27%","Portal Paladin",9020
-"Bristle Woods Rift","Gearworks","Brie String","-","5.41%","Portal Plunderer",9020
-"Bristle Woods Rift","Gearworks","Brie String","-","0.28%","Portal Pursuer",9020
-"Bristle Woods Rift","Guard Barracks","Brie String","-","39.60%","Portal Paladin",1462
-"Bristle Woods Rift","Guard Barracks","Brie String","-","27.15%","Clockwork Timespinner",1462
-"Bristle Woods Rift","Guard Barracks","Brie String","-","24.08%","Sentient Slime",1462
-"Bristle Woods Rift","Guard Barracks","Brie String","-","8.69%","Dread Knight",1462
-"Bristle Woods Rift","Guard Barracks","Brie String","-","0.48%","Portal Pursuer",1462
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","35.22%","Portal Plunderer",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","11.57%","Dread Knight",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","10.26%","Timeslither Pythoness",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","9.91%","Timeless Lich",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","8.87%","Epoch Golem",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","6.52%","Carrion Medium",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","5.39%","Portal Paladin",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","4.96%","Shackled Servant",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","4.78%","Skeletal Champion",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","2.17%","Harbinger of Death",1150
-"Bristle Woods Rift","Hidden Treasury","Brie String","-","0.35%","Portal Pursuer",1150
-"Bristle Woods Rift","Ingress","Brie String","-","32.57%","Portal Pursuer",651
-"Bristle Woods Rift","Ingress","Brie String","-","27.19%","Sentient Slime",651
-"Bristle Woods Rift","Ingress","Brie String","-","19.05%","Clockwork Timespinner",651
-"Bristle Woods Rift","Ingress","Brie String","-","9.98%","Vigilant Ward",651
-"Bristle Woods Rift","Ingress","Brie String","-","6.30%","Shackled Servant",651
-"Bristle Woods Rift","Ingress","Brie String","-","3.23%","Dread Knight",651
-"Bristle Woods Rift","Ingress","Brie String","-","1.69%","Harbinger of Death",651
-"Bristle Woods Rift","Lucky Tower","Brie String","-","20.73%","Portal Plunderer",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","20.03%","Clockwork Timespinner",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","11.01%","Sentient Slime",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","10.62%","Record Keeper",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","10.50%","Record Keeper's Assistant",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","10.43%","Dread Knight",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","5.80%","Skeletal Champion",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","5.47%","Epoch Golem",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","3.73%","Portal Paladin",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","1.29%","Harbinger of Death",1553
-"Bristle Woods Rift","Lucky Tower","Brie String","-","0.39%","Portal Pursuer",1553
-"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","83.65%","Skeletal Champion",263
-"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","11.03%","Portal Pursuer",263
-"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","5.32%","Record Keeper's Assistant",263
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","37.72%","Sentient Slime",1445
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","25.81%","Dread Knight",1445
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","14.60%","Vigilant Ward",1445
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","8.65%","Shackled Servant",1445
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","5.26%","Skeletal Champion",1445
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","4.78%","Portal Paladin",1445
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","2.21%","Harbinger of Death",1445
-"Bristle Woods Rift","Runic Laboratory","Brie String","-","0.97%","Portal Pursuer",1445
-"Bristle Woods Rift","Security","Brie String","-","89.55%","Skeletal Champion",574
-"Bristle Woods Rift","Security","Brie String","-","4.53%","Vigilant Ward",574
-"Bristle Woods Rift","Security","Brie String","-","2.79%","Timelost Thaumaturge",574
-"Bristle Woods Rift","Security","Brie String","-","1.74%","Shackled Servant",574
-"Bristle Woods Rift","Security","Brie String","-","1.39%","Portal Pursuer",574
-"Bristle Woods Rift","Timewarp","Brie String","-","40.13%","Dread Knight",1186
-"Bristle Woods Rift","Timewarp","Brie String","-","39.21%","Sentient Slime",1186
-"Bristle Woods Rift","Timewarp","Brie String","-","8.52%","Carrion Medium",1186
-"Bristle Woods Rift","Timewarp","Brie String","-","5.40%","Skeletal Champion",1186
-"Bristle Woods Rift","Timewarp","Brie String","-","3.63%","Portal Paladin",1186
-"Bristle Woods Rift","Timewarp","Brie String","-","2.53%","Timeless Lich",1186
-"Bristle Woods Rift","Timewarp","Brie String","-","0.59%","Portal Pursuer",1186
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","26.36%","Portal Plunderer",1749
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","26.13%","Clockwork Timespinner",1749
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","16.07%","Record Keeper",1749
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","9.72%","Skeletal Champion",1749
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","7.43%","Record Keeper's Assistant",1749
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","6.58%","Portal Paladin",1749
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","5.77%","Sentient Slime",1749
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","1.77%","Dread Knight",1749
-"Bristle Woods Rift","Ancient Lab","Swiss String","-","0.17%","Portal Pursuer",1749
-"Bristle Woods Rift","Gearworks","Swiss String","-","23.21%","Sentient Slime",504
-"Bristle Woods Rift","Gearworks","Swiss String","-","20.24%","Record Keeper's Assistant",504
-"Bristle Woods Rift","Gearworks","Swiss String","-","17.46%","Record Keeper",504
-"Bristle Woods Rift","Gearworks","Swiss String","-","14.29%","Skeletal Champion",504
-"Bristle Woods Rift","Gearworks","Swiss String","-","8.73%","Dread Knight",504
-"Bristle Woods Rift","Gearworks","Swiss String","-","7.94%","Portal Paladin",504
-"Bristle Woods Rift","Gearworks","Swiss String","-","5.36%","Clockwork Timespinner",504
-"Bristle Woods Rift","Gearworks","Swiss String","-","2.78%","Portal Plunderer",504
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","42.77%","Sentient Slime",159
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","23.27%","Dread Knight",159
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","18.87%","Vigilant Ward",159
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","5.66%","Skeletal Champion",159
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","4.40%","Shackled Servant",159
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","3.14%","Harbinger of Death",159
-"Bristle Woods Rift","Runic Laboratory","Swiss String","-","1.89%","Portal Paladin",159
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","33.10%","Dread Knight",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","12.59%","Vigilant Ward",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","11.08%","Absolute Acolyte",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","9.43%","Timelost Thaumaturge",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","7.41%","Timeslither Pythoness",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","6.65%","Shackled Servant",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","5.70%","Portal Paladin",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","5.19%","Harbinger of Death",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","5.06%","Carrion Medium",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","2.85%","Timeless Lich",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","0.70%","Chronomaster",1580
-"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","0.25%","Portal Pursuer",1580
-"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","34.18%","Carrion Medium",1840
-"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","27.88%","Chronomaster",1840
-"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","20.05%","Timeless Lich",1840
-"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","11.90%","Sentient Slime",1840
-"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","5.87%","Portal Paladin",1840
-"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","0.11%","Portal Pursuer",1840
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","33.23%","Timelost Thaumaturge",328
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","19.82%","Shackled Servant",328
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","18.60%","Vigilant Ward",328
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","11.28%","Timeslither Pythoness",328
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","8.84%","Sentient Slime",328
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","4.27%","Portal Paladin",328
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","3.35%","Harbinger of Death",328
-"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","0.61%","Portal Pursuer",328
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","44.10%","Clockwork Timespinner",229
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","41.05%","Portal Plunderer",229
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","6.55%","Record Keeper",229
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","3.06%","Epoch Golem",229
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","2.62%","Portal Paladin",229
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","1.31%","Dread Knight",229
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","0.87%","Sentient Slime",229
-"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","0.44%","Record Keeper's Assistant",229
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","45.37%","Portal Plunderer",108
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","11.11%","Carrion Medium",108
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","8.33%","Dread Knight",108
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","7.41%","Epoch Golem",108
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","7.41%","Portal Paladin",108
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","7.41%","Timeslither Pythoness",108
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","6.48%","Timeless Lich",108
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","3.70%","Harbinger of Death",108
-"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","2.78%","Shackled Servant",108
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","24.64%","Clockwork Timespinner",138
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","20.29%","Portal Plunderer",138
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","13.04%","Record Keeper",138
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.59%","Dread Knight",138
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.59%","Record Keeper's Assistant",138
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","8.70%","Sentient Slime",138
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","7.97%","Epoch Golem",138
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","1.45%","Portal Paladin",138
-"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","0.72%","Harbinger of Death",138
+"Bristle Woods Rift","Acolyte","Runic String","-","23.90%","Skeletal Champion",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","8.05%","Absolute Acolyte",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","6.38%","Timelost Thaumaturge",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","5.47%","Timeslither Pythoness",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","5.36%","Shackled Servant",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","3.72%","Harbinger of Death",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","3.66%","Carrion Medium",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","2.32%","Timeless Lich",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","0.49%","Chronomaster",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","7.74%","Portal Paladin",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","9.21%","Vigilant Ward",50105
+"Bristle Woods Rift","Acolyte","Runic String","-","23.69%","Dread Knight",50105
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","8.43%","Timelost Thaumaturge",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","7.19%","Timeslither Pythoness",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","31.12%","Dread Knight",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","12.15%","Vigilant Ward",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","10.50%","Absolute Acolyte",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","10.08%","Portal Paladin",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","7.14%","Shackled Servant",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","4.89%","Harbinger of Death",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","4.84%","Carrion Medium",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","3.02%","Timeless Lich",55157
+"Bristle Woods Rift","Acolyte","Runic String","Rift Antiskele","0.64%","Chronomaster",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","6.92%","Timelost Thaumaturge",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","8.72%","Absolute Acolyte",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","5.81%","Shackled Servant",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","4.03%","Harbinger of Death",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","3.97%","Carrion Medium",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","9.98%","Vigilant Ward",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","2.52%","Timeless Lich",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","0.53%","Chronomaster",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","25.68%","Dread Knight",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","25.91%","Skeletal Champion",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","-","5.93%","Timeslither Pythoness",50105
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","5.43%","Harbinger of Death",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","7.94%","Shackled Servant",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","8.00%","Timeslither Pythoness",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","9.38%","Timelost Thaumaturge",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","11.68%","Absolute Acolyte",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","13.51%","Vigilant Ward",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","3.36%","Timeless Lich",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","34.60%","Dread Knight",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","0.71%","Chronomaster",55157
+"Bristle Woods Rift","Acolyte (Paladin's Bane)","Runic String","Rift Antiskele","5.39%","Carrion Medium",55157
+"Bristle Woods Rift","Ancient Lab","Runic String","-","0.83%","Record Keeper's Assistant",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","0.69%","Sentient Slime",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","14.04%","Portal Plunderer",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","5.32%","Skeletal Champion",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","24.55%","Chamber Cleaver",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","13.13%","Dread Knight",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","3.44%","Portal Paladin",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","34.74%","Epoch Golem",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","2.16%","Clockwork Timespinner",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","-","1.10%","Record Keeper",2182
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","25.67%","Chamber Cleaver",2338
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","14.91%","Portal Plunderer",2338
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","13.87%","Dread Knight",2338
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","3.62%","Portal Paladin",2338
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","2.26%","Clockwork Timespinner",2338
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","1.08%","Record Keeper",2338
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","0.81%","Record Keeper's Assistant",2338
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","0.68%","Sentient Slime",2338
+"Bristle Woods Rift","Ancient Lab","Runic String","Rift Antiskele","37.10%","Epoch Golem",2338
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","1.13%","Sentient Slime",1603
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","44.05%","Epoch Golem",1603
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","22.31%","Portal Plunderer",1603
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","9.40%","Dread Knight",1603
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","5.89%","Portal Paladin",1603
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","5.70%","Skeletal Champion",1603
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","5.14%","Record Keeper",1603
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","4.14%","Clockwork Timespinner",1603
+"Bristle Woods Rift","Ancient Lab","Ancient String","-","2.26%","Record Keeper's Assistant",1603
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","5.58%","Record Keeper",1750
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","46.76%","Epoch Golem",1750
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","23.83%","Portal Plunderer",1750
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","9.82%","Dread Knight",1750
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","6.00%","Portal Paladin",1750
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","4.49%","Clockwork Timespinner",1750
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","1.15%","Sentient Slime",1750
+"Bristle Woods Rift","Ancient Lab","Ancient String","Rift Antiskele","2.37%","Record Keeper's Assistant",1750
+"Bristle Woods Rift","Ancient Lab","Magical String","-","5.17%","Record Keeper's Assistant",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","5.58%","Portal Paladin",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","13.25%","Clockwork Timespinner",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","4.96%","Sentient Slime",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","21.21%","Portal Plunderer",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","40.09%","Epoch Golem",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","4.86%","Skeletal Champion",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","-","4.88%","Record Keeper",3871
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","5.98%","Portal Paladin",4179
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","5.38%","Record Keeper's Assistant",4179
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","5.15%","Sentient Slime",4179
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","5.13%","Record Keeper",4179
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","22.37%","Portal Plunderer",4179
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","42.02%","Epoch Golem",4179
+"Bristle Woods Rift","Ancient Lab","Magical String","Rift Antiskele","13.97%","Clockwork Timespinner",4179
+"Bristle Woods Rift","Ancient Lab","Brie String","-","40.95%","Clockwork Timespinner",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","-","37.23%","Portal Plunderer",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","-","5.37%","Skeletal Champion",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","-","1.07%","Dread Knight",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","-","5.21%","Record Keeper",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","-","4.97%","Portal Paladin",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","-","4.19%","Epoch Golem",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","-","0.50%","Record Keeper's Assistant",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","-","0.51%","Sentient Slime",42312
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","1.09%","Dread Knight",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","4.41%","Epoch Golem",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","5.30%","Portal Paladin",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","5.51%","Record Keeper",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","39.28%","Portal Plunderer",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","43.36%","Clockwork Timespinner",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","0.52%","Record Keeper's Assistant",47427
+"Bristle Woods Rift","Ancient Lab","Brie String","Rift Antiskele","0.53%","Sentient Slime",47427
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","26.37%","Portal Plunderer",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","8.99%","Skeletal Champion",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","16.64%","Record Keeper",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","8.06%","Record Keeper's Assistant",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","6.29%","Portal Paladin",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","5.68%","Sentient Slime",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","1.82%","Dread Knight",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","-","26.14%","Clockwork Timespinner",2155
+"Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","28.45%","Portal Plunderer",2302
+"Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","18.76%","Record Keeper",2302
+"Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","9.07%","Record Keeper's Assistant",2302
+"Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","6.67%","Portal Paladin",2302
+"Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","6.24%","Sentient Slime",2302
+"Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","1.97%","Dread Knight",2302
+"Bristle Woods Rift","Ancient Lab","Swiss String","Rift Antiskele","28.84%","Clockwork Timespinner",2302
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","0.86%","Record Keeper's Assistant",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","13.59%","Dread Knight",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","0.71%","Sentient Slime",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","14.54%","Portal Plunderer",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","5.51%","Skeletal Champion",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","35.98%","Epoch Golem",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","2.23%","Clockwork Timespinner",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","25.43%","Chamber Cleaver",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","-","1.14%","Record Keeper",2182
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","0.70%","Sentient Slime",2338
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","38.49%","Epoch Golem",2338
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","26.63%","Chamber Cleaver",2338
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","15.47%","Portal Plunderer",2338
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","14.39%","Dread Knight",2338
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","2.34%","Clockwork Timespinner",2338
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","1.13%","Record Keeper",2338
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Runic String","Rift Antiskele","0.84%","Record Keeper's Assistant",2338
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","6.06%","Skeletal Champion",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","46.80%","Epoch Golem",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","23.70%","Portal Plunderer",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","1.20%","Sentient Slime",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","2.40%","Record Keeper's Assistant",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","4.39%","Clockwork Timespinner",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","5.46%","Record Keeper",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","-","9.99%","Dread Knight",1603
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","5.94%","Record Keeper",1750
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","4.77%","Clockwork Timespinner",1750
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","2.52%","Record Keeper's Assistant",1750
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","1.23%","Sentient Slime",1750
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","49.74%","Epoch Golem",1750
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","25.35%","Portal Plunderer",1750
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Ancient String","Rift Antiskele","10.45%","Dread Knight",1750
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","5.14%","Skeletal Champion",3871
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","42.46%","Epoch Golem",3871
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","22.46%","Portal Plunderer",3871
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","14.04%","Clockwork Timespinner",3871
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","5.47%","Record Keeper's Assistant",3871
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","5.25%","Sentient Slime",3871
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","-","5.17%","Record Keeper",3871
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","44.69%","Epoch Golem",4179
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","14.86%","Clockwork Timespinner",4179
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","5.72%","Record Keeper's Assistant",4179
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","5.48%","Sentient Slime",4179
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","5.45%","Record Keeper",4179
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Magical String","Rift Antiskele","23.79%","Portal Plunderer",4179
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","5.65%","Skeletal Champion",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","43.09%","Clockwork Timespinner",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","5.48%","Record Keeper",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","4.41%","Epoch Golem",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","1.13%","Dread Knight",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","0.53%","Sentient Slime",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","0.53%","Record Keeper's Assistant",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","-","39.17%","Portal Plunderer",42312
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","45.79%","Clockwork Timespinner",47427
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","5.82%","Record Keeper",47427
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","4.66%","Epoch Golem",47427
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","1.15%","Dread Knight",47427
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","0.56%","Sentient Slime",47427
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","0.55%","Record Keeper's Assistant",47427
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Brie String","Rift Antiskele","41.48%","Portal Plunderer",47427
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","6.07%","Sentient Slime",2155
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","1.94%","Dread Knight",2155
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","27.90%","Clockwork Timespinner",2155
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","28.15%","Portal Plunderer",2155
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","17.75%","Record Keeper",2155
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","9.60%","Skeletal Champion",2155
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","-","8.60%","Record Keeper's Assistant",2155
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","6.68%","Sentient Slime",2302
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","30.90%","Clockwork Timespinner",2302
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","30.49%","Portal Plunderer",2302
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","20.10%","Record Keeper",2302
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","9.72%","Record Keeper's Assistant",2302
+"Bristle Woods Rift","Ancient Lab (Paladin's Bane)","Swiss String","Rift Antiskele","2.11%","Dread Knight",2302
+"Bristle Woods Rift","Entrance","Runic String","-","0.62%","Clockwork Timespinner",325
+"Bristle Woods Rift","Entrance","Runic String","-","3.69%","Portal Plunderer",325
+"Bristle Woods Rift","Entrance","Runic String","-","3.08%","Skeletal Champion",325
+"Bristle Woods Rift","Entrance","Runic String","-","3.08%","Epoch Golem",325
+"Bristle Woods Rift","Entrance","Runic String","-","0.62%","Sentient Slime",325
+"Bristle Woods Rift","Entrance","Runic String","-","10.46%","Portal Paladin",325
+"Bristle Woods Rift","Entrance","Runic String","-","78.46%","Vigilant Ward",325
+"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","3.92%","Portal Plunderer",368
+"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","0.56%","Sentient Slime",368
+"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","80.95%","Vigilant Ward",368
+"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","10.64%","Portal Paladin",368
+"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","0.56%","Clockwork Timespinner",368
+"Bristle Woods Rift","Entrance","Runic String","Rift Antiskele","3.36%","Epoch Golem",368
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","0.69%","Sentient Slime",325
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","0.69%","Clockwork Timespinner",325
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","3.44%","Epoch Golem",325
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","87.63%","Vigilant Ward",325
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","4.12%","Portal Plunderer",325
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","-","3.44%","Skeletal Champion",325
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","0.63%","Sentient Slime",368
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","0.63%","Clockwork Timespinner",368
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","90.60%","Vigilant Ward",368
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","3.76%","Epoch Golem",368
+"Bristle Woods Rift","Entrance (Paladin's Bane)","Runic String","Rift Antiskele","4.39%","Portal Plunderer",368
+"Bristle Woods Rift","Frozen Alcove","Runic String","-","0.51%","Harbinger of Death",4344
+"Bristle Woods Rift","Frozen Alcove","Runic String","-","38.59%","Dread Knight",4344
+"Bristle Woods Rift","Frozen Alcove","Runic String","-","6.11%","Portal Paladin",4344
+"Bristle Woods Rift","Frozen Alcove","Runic String","-","54.79%","Sentient Slime",4344
+"Bristle Woods Rift","Frozen Alcove","Runic String","Rift Antiskele","38.79%","Dread Knight",4474
+"Bristle Woods Rift","Frozen Alcove","Runic String","Rift Antiskele","6.15%","Portal Paladin",4474
+"Bristle Woods Rift","Frozen Alcove","Runic String","Rift Antiskele","0.49%","Harbinger of Death",4474
+"Bristle Woods Rift","Frozen Alcove","Runic String","Rift Antiskele","54.56%","Sentient Slime",4474
+"Bristle Woods Rift","Frozen Alcove","Ancient String","-","54.92%","Sentient Slime",1551
+"Bristle Woods Rift","Frozen Alcove","Ancient String","-","36.29%","Dread Knight",1551
+"Bristle Woods Rift","Frozen Alcove","Ancient String","-","8.60%","Portal Paladin",1551
+"Bristle Woods Rift","Frozen Alcove","Ancient String","-","0.19%","Harbinger of Death",1551
+"Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","8.55%","Portal Paladin",1597
+"Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","0.19%","Harbinger of Death",1597
+"Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","36.39%","Dread Knight",1597
+"Bristle Woods Rift","Frozen Alcove","Ancient String","Rift Antiskele","54.87%","Sentient Slime",1597
+"Bristle Woods Rift","Frozen Alcove","Magical String","-","8.50%","Portal Paladin",1353
+"Bristle Woods Rift","Frozen Alcove","Magical String","-","11.75%","Dread Knight",1353
+"Bristle Woods Rift","Frozen Alcove","Magical String","-","79.75%","Sentient Slime",1353
+"Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","11.66%","Dread Knight",1450
+"Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","0.07%","Harbinger of Death",1450
+"Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","79.79%","Sentient Slime",1450
+"Bristle Woods Rift","Frozen Alcove","Magical String","Rift Antiskele","8.48%","Portal Paladin",1450
+"Bristle Woods Rift","Frozen Alcove","Brie String","-","80.12%","Sentient Slime",1385
+"Bristle Woods Rift","Frozen Alcove","Brie String","-","11.04%","Dread Knight",1385
+"Bristle Woods Rift","Frozen Alcove","Brie String","-","8.85%","Portal Paladin",1385
+"Bristle Woods Rift","Frozen Alcove","Brie String","Rift Antiskele","11.21%","Dread Knight",1519
+"Bristle Woods Rift","Frozen Alcove","Brie String","Rift Antiskele","8.88%","Portal Paladin",1519
+"Bristle Woods Rift","Frozen Alcove","Brie String","Rift Antiskele","79.91%","Sentient Slime",1519
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","-","41.10%","Dread Knight",4344
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","-","58.36%","Sentient Slime",4344
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","-","0.54%","Harbinger of Death",4344
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","Rift Antiskele","58.14%","Sentient Slime",4474
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","Rift Antiskele","41.33%","Dread Knight",4474
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Runic String","Rift Antiskele","0.52%","Harbinger of Death",4474
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","-","60.08%","Sentient Slime",1551
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","-","39.70%","Dread Knight",1551
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","-","0.21%","Harbinger of Death",1551
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","Rift Antiskele","0.21%","Harbinger of Death",1597
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","Rift Antiskele","39.79%","Dread Knight",1597
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Ancient String","Rift Antiskele","60.00%","Sentient Slime",1597
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","-","87.16%","Sentient Slime",1353
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","-","12.84%","Dread Knight",1353
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","Rift Antiskele","12.74%","Dread Knight",1450
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","Rift Antiskele","0.08%","Harbinger of Death",1450
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Magical String","Rift Antiskele","87.19%","Sentient Slime",1450
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","-","12.11%","Dread Knight",1385
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","-","87.89%","Sentient Slime",1385
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","Rift Antiskele","87.69%","Sentient Slime",1519
+"Bristle Woods Rift","Frozen Alcove (Paladin's Bane)","Brie String","Rift Antiskele","12.31%","Dread Knight",1519
+"Bristle Woods Rift","Furnace Room","Brie String","-","2.80%","Portal Paladin",328
+"Bristle Woods Rift","Furnace Room","Brie String","-","91.90%","Skeletal Champion",328
+"Bristle Woods Rift","Furnace Room","Brie String","-","1.56%","Dread Knight",328
+"Bristle Woods Rift","Furnace Room","Brie String","-","1.87%","Clockwork Timespinner",328
+"Bristle Woods Rift","Furnace Room","Brie String","-","1.87%","Portal Plunderer",328
+"Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","31.25%","Clockwork Timespinner",419
+"Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","35.42%","Portal Paladin",419
+"Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","16.67%","Dread Knight",419
+"Bristle Woods Rift","Furnace Room","Brie String","Rift Antiskele","16.67%","Portal Plunderer",419
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.92%","Portal Plunderer",328
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","94.55%","Skeletal Champion",328
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.60%","Dread Knight",328
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","-","1.92%","Clockwork Timespinner",328
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","48.39%","Clockwork Timespinner",419
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","25.81%","Dread Knight",419
+"Bristle Woods Rift","Furnace Room (Paladin's Bane)","Brie String","Rift Antiskele","25.81%","Portal Plunderer",419
+"Bristle Woods Rift","Gearworks","Runic String","-","0.27%","Timelost Thaumaturge",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","0.90%","Record Keeper's Assistant",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","2.17%","Record Keeper",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","25.21%","Chamber Cleaver",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","6.18%","Portal Paladin",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","37.44%","Dread Knight",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","0.05%","Harbinger of Death",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","0.09%","Shackled Servant",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","0.18%","Vigilant Ward",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","11.37%","Portal Plunderer",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","4.15%","Clockwork Timespinner",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","8.71%","Skeletal Champion",2221
+"Bristle Woods Rift","Gearworks","Runic String","-","3.29%","Sentient Slime",2221
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.27%","Timelost Thaumaturge",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.05%","Harbinger of Death",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","3.60%","Sentient Slime",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","4.77%","Clockwork Timespinner",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","6.93%","Portal Paladin",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","12.92%","Portal Plunderer",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","26.65%","Chamber Cleaver",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","41.06%","Dread Knight",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.27%","Vigilant Ward",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.05%","Timeslither Pythoness",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.99%","Record Keeper's Assistant",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","2.34%","Record Keeper",2427
+"Bristle Woods Rift","Gearworks","Runic String","Rift Antiskele","0.09%","Shackled Servant",2427
+"Bristle Woods Rift","Gearworks","Ancient String","-","8.81%","Sentient Slime",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","38.49%","Dread Knight",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","7.55%","Record Keeper",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","7.91%","Skeletal Champion",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","5.94%","Portal Paladin",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","8.99%","Clockwork Timespinner",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","9.17%","Record Keeper's Assistant",564
+"Bristle Woods Rift","Gearworks","Ancient String","-","13.13%","Portal Plunderer",564
+"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","10.21%","Record Keeper's Assistant",635
+"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","41.35%","Dread Knight",635
+"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","13.84%","Portal Plunderer",635
+"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","10.03%","Sentient Slime",635
+"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","10.03%","Clockwork Timespinner",635
+"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","8.13%","Record Keeper",635
+"Bristle Woods Rift","Gearworks","Ancient String","Rift Antiskele","6.40%","Portal Paladin",635
+"Bristle Woods Rift","Gearworks","Magical String","-","20.61%","Record Keeper's Assistant",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","4.51%","Clockwork Timespinner",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","4.13%","Epoch Golem",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","8.89%","Portal Paladin",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","9.03%","Skeletal Champion",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","4.27%","Portal Plunderer",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","14.65%","Sentient Slime",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","16.47%","Dread Knight",2082
+"Bristle Woods Rift","Gearworks","Magical String","-","17.44%","Record Keeper",2082
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","16.22%","Sentient Slime",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","4.90%","Clockwork Timespinner",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","9.55%","Portal Paladin",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","19.55%","Record Keeper",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","22.54%","Record Keeper's Assistant",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","4.51%","Epoch Golem",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","4.61%","Portal Plunderer",2232
+"Bristle Woods Rift","Gearworks","Magical String","Rift Antiskele","18.13%","Dread Knight",2232
+"Bristle Woods Rift","Gearworks","Brie String","-","7.33%","Portal Paladin",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","5.43%","Portal Plunderer",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","13.35%","Sentient Slime",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","11.82%","Skeletal Champion",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","15.08%","Record Keeper",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","16.73%","Dread Knight",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","22.75%","Record Keeper's Assistant",13024
+"Bristle Woods Rift","Gearworks","Brie String","-","7.51%","Clockwork Timespinner",13024
+"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","17.35%","Record Keeper",14344
+"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","15.10%","Sentient Slime",14344
+"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","8.33%","Clockwork Timespinner",14344
+"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","8.31%","Portal Paladin",14344
+"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","18.77%","Dread Knight",14344
+"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","25.96%","Record Keeper's Assistant",14344
+"Bristle Woods Rift","Gearworks","Brie String","Rift Antiskele","6.19%","Portal Plunderer",14344
+"Bristle Woods Rift","Gearworks","Swiss String","-","8.52%","Portal Paladin",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","15.48%","Skeletal Champion",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","16.19%","Record Keeper",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","19.18%","Record Keeper's Assistant",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","8.24%","Dread Knight",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","23.72%","Sentient Slime",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","5.40%","Clockwork Timespinner",704
+"Bristle Woods Rift","Gearworks","Swiss String","-","3.27%","Portal Plunderer",704
+"Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","28.73%","Sentient Slime",734
+"Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","18.62%","Record Keeper",734
+"Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","10.27%","Portal Paladin",734
+"Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","9.79%","Dread Knight",734
+"Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","6.10%","Clockwork Timespinner",734
+"Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","3.69%","Portal Plunderer",734
+"Bristle Woods Rift","Gearworks","Swiss String","Rift Antiskele","22.79%","Record Keeper's Assistant",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.96%","Record Keeper's Assistant",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.19%","Vigilant Ward",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.10%","Shackled Servant",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.05%","Harbinger of Death",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","9.28%","Skeletal Champion",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","26.88%","Chamber Cleaver",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","39.90%","Dread Knight",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","3.51%","Sentient Slime",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","2.31%","Record Keeper",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","12.12%","Portal Plunderer",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","0.29%","Timelost Thaumaturge",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","-","4.42%","Clockwork Timespinner",2221
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.29%","Timelost Thaumaturge",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.29%","Vigilant Ward",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","1.06%","Record Keeper's Assistant",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","44.12%","Dread Knight",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","28.64%","Chamber Cleaver",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","13.88%","Portal Plunderer",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","2.52%","Record Keeper",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","3.87%","Sentient Slime",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","5.13%","Clockwork Timespinner",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.05%","Timeslither Pythoness",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.05%","Harbinger of Death",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Runic String","Rift Antiskele","0.10%","Shackled Servant",2427
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","8.41%","Skeletal Champion",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","9.37%","Sentient Slime",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","9.56%","Clockwork Timespinner",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","9.75%","Record Keeper's Assistant",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","13.96%","Portal Plunderer",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","40.92%","Dread Knight",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","-","8.03%","Record Keeper",564
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","10.72%","Clockwork Timespinner",635
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","14.79%","Portal Plunderer",635
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","10.91%","Record Keeper's Assistant",635
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","44.18%","Dread Knight",635
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","8.69%","Record Keeper",635
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Ancient String","Rift Antiskele","10.72%","Sentient Slime",635
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","4.69%","Portal Plunderer",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","4.96%","Clockwork Timespinner",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","9.91%","Skeletal Champion",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","16.08%","Sentient Slime",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","18.08%","Dread Knight",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","19.14%","Record Keeper",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","22.61%","Record Keeper's Assistant",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","-","4.53%","Epoch Golem",2082
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","20.04%","Dread Knight",2232
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","17.93%","Sentient Slime",2232
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","5.42%","Clockwork Timespinner",2232
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","5.09%","Portal Plunderer",2232
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","4.98%","Epoch Golem",2232
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","24.92%","Record Keeper's Assistant",2232
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Magical String","Rift Antiskele","21.61%","Record Keeper",2232
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","8.10%","Clockwork Timespinner",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","5.85%","Portal Plunderer",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","24.55%","Record Keeper's Assistant",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","12.76%","Skeletal Champion",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","14.41%","Sentient Slime",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","16.28%","Record Keeper",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","-","18.05%","Dread Knight",13024
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","6.75%","Portal Plunderer",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","16.46%","Sentient Slime",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","18.92%","Record Keeper",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","20.47%","Dread Knight",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","9.09%","Clockwork Timespinner",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Brie String","Rift Antiskele","28.31%","Record Keeper's Assistant",14344
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","16.93%","Skeletal Champion",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","9.01%","Dread Knight",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","20.96%","Record Keeper's Assistant",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","17.70%","Record Keeper",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","5.90%","Clockwork Timespinner",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","3.57%","Portal Plunderer",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","-","25.93%","Sentient Slime",704
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","20.75%","Record Keeper",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","25.40%","Record Keeper's Assistant",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","32.02%","Sentient Slime",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","6.80%","Clockwork Timespinner",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","4.11%","Portal Plunderer",734
+"Bristle Woods Rift","Gearworks (Paladin's Bane)","Swiss String","Rift Antiskele","10.91%","Dread Knight",734
+"Bristle Woods Rift","Guard Barracks","Runic String","-","1.06%","Sentient Slime",6785
+"Bristle Woods Rift","Guard Barracks","Runic String","-","65.46%","Portal Paladin",6785
+"Bristle Woods Rift","Guard Barracks","Runic String","-","17.98%","Dread Knight",6785
+"Bristle Woods Rift","Guard Barracks","Runic String","-","13.45%","Epoch Golem",6785
+"Bristle Woods Rift","Guard Barracks","Runic String","-","2.05%","Clockwork Timespinner",6785
+"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","2.01%","Clockwork Timespinner",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","65.45%","Portal Paladin",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","18.05%","Dread Knight",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","13.45%","Epoch Golem",6969
+"Bristle Woods Rift","Guard Barracks","Runic String","Rift Antiskele","1.03%","Sentient Slime",6969
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","6.19%","Clockwork Timespinner",2029
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","57.48%","Portal Paladin",2029
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","15.56%","Dread Knight",2029
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","11.55%","Sentient Slime",2029
+"Bristle Woods Rift","Guard Barracks","Ancient String","-","9.22%","Epoch Golem",2029
+"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","9.36%","Epoch Golem",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","57.16%","Portal Paladin",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","15.77%","Dread Knight",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","11.58%","Sentient Slime",2084
+"Bristle Woods Rift","Guard Barracks","Ancient String","Rift Antiskele","6.13%","Clockwork Timespinner",2084
+"Bristle Woods Rift","Guard Barracks","Magical String","-","11.96%","Epoch Golem",1864
+"Bristle Woods Rift","Guard Barracks","Magical String","-","14.38%","Clockwork Timespinner",1864
+"Bristle Woods Rift","Guard Barracks","Magical String","-","18.03%","Sentient Slime",1864
+"Bristle Woods Rift","Guard Barracks","Magical String","-","10.57%","Dread Knight",1864
+"Bristle Woods Rift","Guard Barracks","Magical String","-","45.06%","Portal Paladin",1864
+"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","10.55%","Dread Knight",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","18.04%","Sentient Slime",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","11.97%","Epoch Golem",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","44.94%","Portal Paladin",1896
+"Bristle Woods Rift","Guard Barracks","Magical String","Rift Antiskele","14.50%","Clockwork Timespinner",1896
+"Bristle Woods Rift","Guard Barracks","Brie String","-","41.27%","Portal Paladin",2154
+"Bristle Woods Rift","Guard Barracks","Brie String","-","9.01%","Dread Knight",2154
+"Bristle Woods Rift","Guard Barracks","Brie String","-","23.11%","Sentient Slime",2154
+"Bristle Woods Rift","Guard Barracks","Brie String","-","26.61%","Clockwork Timespinner",2154
+"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","23.07%","Sentient Slime",2309
+"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","9.19%","Dread Knight",2309
+"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","41.05%","Portal Paladin",2309
+"Bristle Woods Rift","Guard Barracks","Brie String","Rift Antiskele","26.69%","Clockwork Timespinner",2309
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","3.08%","Sentient Slime",6785
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","5.94%","Clockwork Timespinner",6785
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","38.93%","Epoch Golem",6785
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","-","52.05%","Dread Knight",6785
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","52.25%","Dread Knight",6969
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","38.94%","Epoch Golem",6969
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","5.82%","Clockwork Timespinner",6969
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Runic String","Rift Antiskele","3.00%","Sentient Slime",6969
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","21.68%","Epoch Golem",2029
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","27.16%","Sentient Slime",2029
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","36.60%","Dread Knight",2029
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","-","14.57%","Clockwork Timespinner",2029
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","14.30%","Clockwork Timespinner",2084
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","27.03%","Sentient Slime",2084
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","36.82%","Dread Knight",2084
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Ancient String","Rift Antiskele","21.85%","Epoch Golem",2084
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","32.81%","Sentient Slime",1864
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","26.17%","Clockwork Timespinner",1864
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","21.78%","Epoch Golem",1864
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","-","19.24%","Dread Knight",1864
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","32.76%","Sentient Slime",1896
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","26.34%","Clockwork Timespinner",1896
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","19.16%","Dread Knight",1896
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Magical String","Rift Antiskele","21.74%","Epoch Golem",1896
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","45.31%","Clockwork Timespinner",2154
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","15.34%","Dread Knight",2154
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","-","39.35%","Sentient Slime",2154
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","Rift Antiskele","45.27%","Clockwork Timespinner",2309
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","Rift Antiskele","39.14%","Sentient Slime",2309
+"Bristle Woods Rift","Guard Barracks (Paladin's Bane)","Brie String","Rift Antiskele","15.58%","Dread Knight",2309
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","9.26%","Epoch Golem",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.75%","Shackled Servant",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","5.94%","Dread Knight",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.16%","Portal Paladin",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","11.88%","Portal Plunderer",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.28%","Skeletal Champion",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","4.51%","Carrion Medium",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","2.14%","Harbinger of Death",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","25.89%","Timeslither Pythoness",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","-","27.20%","Timeless Lich",842
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","6.03%","Dread Knight",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","27.96%","Timeless Lich",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","26.64%","Timeslither Pythoness",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","12.28%","Portal Plunderer",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","9.98%","Epoch Golem",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","2.19%","Harbinger of Death",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","4.71%","Carrion Medium",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","4.93%","Portal Paladin",950
+"Bristle Woods Rift","Hidden Treasury","Runic String","Rift Antiskele","5.26%","Shackled Servant",950
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","5.74%","Dread Knight",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","3.55%","Skeletal Champion",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","16.39%","Timeless Lich",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","19.95%","Epoch Golem",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","23.77%","Timeslither Pythoness",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","13.93%","Portal Plunderer",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","5.46%","Portal Paladin",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","4.10%","Shackled Servant",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","1.64%","Harbinger of Death",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","-","5.46%","Carrion Medium",366
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","5.11%","Portal Paladin",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","5.84%","Dread Knight",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","1.70%","Harbinger of Death",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","4.14%","Shackled Servant",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","4.87%","Carrion Medium",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","26.03%","Timeslither Pythoness",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","20.19%","Epoch Golem",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","18.00%","Timeless Lich",425
+"Bristle Woods Rift","Hidden Treasury","Ancient String","Rift Antiskele","14.11%","Portal Plunderer",425
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","1.55%","Harbinger of Death",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","3.87%","Carrion Medium",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","4.90%","Shackled Servant",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","5.93%","Dread Knight",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","6.19%","Portal Paladin",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","6.44%","Skeletal Champion",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","10.57%","Portal Plunderer",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","10.82%","Timeslither Pythoness",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","12.89%","Timeless Lich",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","-","36.86%","Epoch Golem",388
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","6.74%","Portal Paladin",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","38.37%","Epoch Golem",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","13.95%","Timeless Lich",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","11.86%","Timeslither Pythoness",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","11.40%","Portal Plunderer",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","6.05%","Shackled Servant",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","5.35%","Dread Knight",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","4.42%","Carrion Medium",458
+"Bristle Woods Rift","Hidden Treasury","Magical String","Rift Antiskele","1.86%","Harbinger of Death",458
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","10.21%","Timeless Lich",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","2.14%","Harbinger of Death",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","35.78%","Portal Plunderer",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","11.55%","Dread Knight",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","10.86%","Timeslither Pythoness",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","8.72%","Epoch Golem",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","6.15%","Carrion Medium",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","5.03%","Skeletal Champion",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","5.03%","Shackled Servant",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","-","4.55%","Portal Paladin",1874
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","2.30%","Harbinger of Death",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","10.76%","Timeless Lich",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","38.19%","Portal Plunderer",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","4.60%","Portal Paladin",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","11.27%","Timeslither Pythoness",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","12.26%","Dread Knight",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","9.07%","Epoch Golem",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","6.58%","Carrion Medium",2237
+"Bristle Woods Rift","Hidden Treasury","Brie String","Rift Antiskele","4.98%","Shackled Servant",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","27.01%","Timeslither Pythoness",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","12.39%","Portal Plunderer",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","4.71%","Carrion Medium",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","4.46%","Skeletal Champion",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","2.23%","Harbinger of Death",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","28.38%","Timeless Lich",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","9.67%","Epoch Golem",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","6.20%","Dread Knight",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","-","4.96%","Shackled Servant",842
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","4.96%","Carrion Medium",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","5.54%","Shackled Servant",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","12.92%","Portal Plunderer",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","28.03%","Timeslither Pythoness",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","29.41%","Timeless Lich",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","6.34%","Dread Knight",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","10.50%","Epoch Golem",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Runic String","Rift Antiskele","2.31%","Harbinger of Death",950
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","21.10%","Epoch Golem",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","25.14%","Timeslither Pythoness",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","14.74%","Portal Plunderer",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","6.07%","Dread Knight",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","5.78%","Carrion Medium",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","4.34%","Shackled Servant",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","3.76%","Skeletal Champion",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","1.73%","Harbinger of Death",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","-","17.34%","Timeless Lich",366
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","21.28%","Epoch Golem",425
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","18.97%","Timeless Lich",425
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","14.87%","Portal Plunderer",425
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","6.15%","Dread Knight",425
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","5.13%","Carrion Medium",425
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","4.36%","Shackled Servant",425
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","1.79%","Harbinger of Death",425
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Ancient String","Rift Antiskele","27.44%","Timeslither Pythoness",425
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","11.54%","Timeslither Pythoness",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","39.29%","Epoch Golem",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","13.74%","Timeless Lich",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","11.26%","Portal Plunderer",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","6.87%","Skeletal Champion",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","6.32%","Dread Knight",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","5.22%","Shackled Servant",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","4.12%","Carrion Medium",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","-","1.65%","Harbinger of Death",388
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","2.00%","Harbinger of Death",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","4.74%","Carrion Medium",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","5.74%","Dread Knight",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","6.48%","Shackled Servant",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","12.22%","Portal Plunderer",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","12.72%","Timeslither Pythoness",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","14.96%","Timeless Lich",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Magical String","Rift Antiskele","41.15%","Epoch Golem",458
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","12.10%","Dread Knight",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","37.48%","Portal Plunderer",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","5.27%","Skeletal Champion",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","5.27%","Shackled Servant",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","6.44%","Carrion Medium",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","9.13%","Epoch Golem",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","2.24%","Harbinger of Death",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","10.70%","Timeless Lich",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","-","11.37%","Timeslither Pythoness",1874
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","9.50%","Epoch Golem",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","6.89%","Carrion Medium",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","5.22%","Shackled Servant",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","40.03%","Portal Plunderer",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","12.85%","Dread Knight",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","11.82%","Timeslither Pythoness",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","11.28%","Timeless Lich",2237
+"Bristle Woods Rift","Hidden Treasury (Paladin's Bane)","Brie String","Rift Antiskele","2.41%","Harbinger of Death",2237
+"Bristle Woods Rift","Ingress","Runic String","-","23.57%","Dread Knight",2365
+"Bristle Woods Rift","Ingress","Runic String","-","14.30%","Vigilant Ward",2365
+"Bristle Woods Rift","Ingress","Runic String","-","24.67%","Clockwork Timespinner",2365
+"Bristle Woods Rift","Ingress","Runic String","-","24.83%","Sentient Slime",2365
+"Bristle Woods Rift","Ingress","Runic String","-","11.31%","Shackled Servant",2365
+"Bristle Woods Rift","Ingress","Runic String","-","1.31%","Harbinger of Death",2365
+"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","23.28%","Dread Knight",2453
+"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","24.59%","Sentient Slime",2453
+"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","25.04%","Clockwork Timespinner",2453
+"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","11.41%","Shackled Servant",2453
+"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","1.26%","Harbinger of Death",2453
+"Bristle Woods Rift","Ingress","Runic String","Rift Antiskele","14.43%","Vigilant Ward",2453
+"Bristle Woods Rift","Ingress","Ancient String","-","20.28%","Sentient Slime",761
+"Bristle Woods Rift","Ingress","Ancient String","-","26.92%","Clockwork Timespinner",761
+"Bristle Woods Rift","Ingress","Ancient String","-","1.75%","Harbinger of Death",761
+"Bristle Woods Rift","Ingress","Ancient String","-","15.03%","Vigilant Ward",761
+"Bristle Woods Rift","Ingress","Ancient String","-","16.08%","Shackled Servant",761
+"Bristle Woods Rift","Ingress","Ancient String","-","19.93%","Dread Knight",761
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","22.07%","Sentient Slime",862
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","26.48%","Clockwork Timespinner",862
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","1.52%","Harbinger of Death",862
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","14.61%","Vigilant Ward",862
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","15.98%","Shackled Servant",862
+"Bristle Woods Rift","Ingress","Ancient String","Rift Antiskele","19.33%","Dread Knight",862
+"Bristle Woods Rift","Ingress","Magical String","-","14.02%","Vigilant Ward",431
+"Bristle Woods Rift","Ingress","Magical String","-","31.06%","Clockwork Timespinner",431
+"Bristle Woods Rift","Ingress","Magical String","-","31.82%","Sentient Slime",431
+"Bristle Woods Rift","Ingress","Magical String","-","2.27%","Harbinger of Death",431
+"Bristle Woods Rift","Ingress","Magical String","-","5.30%","Dread Knight",431
+"Bristle Woods Rift","Ingress","Magical String","-","15.53%","Shackled Servant",431
+"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","31.70%","Sentient Slime",432
+"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","30.94%","Clockwork Timespinner",432
+"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","15.47%","Shackled Servant",432
+"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","2.26%","Harbinger of Death",432
+"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","5.28%","Dread Knight",432
+"Bristle Woods Rift","Ingress","Magical String","Rift Antiskele","14.34%","Vigilant Ward",432
+"Bristle Woods Rift","Ingress","Brie String","-","4.30%","Dread Knight",992
+"Bristle Woods Rift","Ingress","Brie String","-","39.78%","Sentient Slime",992
+"Bristle Woods Rift","Ingress","Brie String","-","9.52%","Shackled Servant",992
+"Bristle Woods Rift","Ingress","Brie String","-","13.67%","Vigilant Ward",992
+"Bristle Woods Rift","Ingress","Brie String","-","2.30%","Harbinger of Death",992
+"Bristle Woods Rift","Ingress","Brie String","-","30.41%","Clockwork Timespinner",992
+"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","31.30%","Clockwork Timespinner",1061
+"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","13.31%","Vigilant Ward",1061
+"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","9.35%","Shackled Servant",1061
+"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","4.25%","Dread Knight",1061
+"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","39.66%","Sentient Slime",1061
+"Bristle Woods Rift","Ingress","Brie String","Rift Antiskele","2.12%","Harbinger of Death",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","23.57%","Dread Knight",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","1.31%","Harbinger of Death",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","11.31%","Shackled Servant",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","14.30%","Vigilant Ward",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","24.67%","Clockwork Timespinner",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","-","24.83%","Sentient Slime",2365
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","11.41%","Shackled Servant",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","14.43%","Vigilant Ward",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","1.26%","Harbinger of Death",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","25.04%","Clockwork Timespinner",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","24.59%","Sentient Slime",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Runic String","Rift Antiskele","23.28%","Dread Knight",2453
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","15.03%","Vigilant Ward",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","16.08%","Shackled Servant",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","19.93%","Dread Knight",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","20.28%","Sentient Slime",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","26.92%","Clockwork Timespinner",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","-","1.75%","Harbinger of Death",761
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","26.48%","Clockwork Timespinner",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","22.07%","Sentient Slime",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","14.61%","Vigilant Ward",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","1.52%","Harbinger of Death",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","19.33%","Dread Knight",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Ancient String","Rift Antiskele","15.98%","Shackled Servant",862
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","31.06%","Clockwork Timespinner",431
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","31.82%","Sentient Slime",431
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","14.02%","Vigilant Ward",431
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","5.30%","Dread Knight",431
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","2.27%","Harbinger of Death",431
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","-","15.53%","Shackled Servant",431
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","2.26%","Harbinger of Death",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","30.94%","Clockwork Timespinner",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","14.34%","Vigilant Ward",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","15.47%","Shackled Servant",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","31.70%","Sentient Slime",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Magical String","Rift Antiskele","5.28%","Dread Knight",432
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","30.41%","Clockwork Timespinner",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","39.78%","Sentient Slime",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","2.30%","Harbinger of Death",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","4.30%","Dread Knight",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","9.52%","Shackled Servant",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","-","13.67%","Vigilant Ward",992
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","9.35%","Shackled Servant",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","13.31%","Vigilant Ward",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","31.30%","Clockwork Timespinner",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","39.66%","Sentient Slime",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","4.25%","Dread Knight",1061
+"Bristle Woods Rift","Ingress (Paladin's Bane)","Brie String","Rift Antiskele","2.12%","Harbinger of Death",1061
+"Bristle Woods Rift","Lucky Tower","Runic String","-","5.52%","Skeletal Champion",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","23.31%","Epoch Golem",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","9.80%","Record Keeper's Assistant",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","5.42%","Portal Paladin",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","10.37%","Record Keeper",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","2.85%","Sentient Slime",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","2.00%","Harbinger of Death",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","11.80%","Dread Knight",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","13.32%","Clockwork Timespinner",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","-","15.60%","Portal Plunderer",1052
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","3.12%","Sentient Slime",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","24.20%","Epoch Golem",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","17.03%","Portal Plunderer",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","13.58%","Clockwork Timespinner",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","1.94%","Harbinger of Death",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","5.56%","Portal Paladin",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","10.71%","Record Keeper",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","10.88%","Record Keeper's Assistant",1246
+"Bristle Woods Rift","Lucky Tower","Runic String","Rift Antiskele","12.98%","Dread Knight",1246
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","14.62%","Clockwork Timespinner",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","10.38%","Dread Knight",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","9.62%","Record Keeper's Assistant",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","22.50%","Epoch Golem",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","7.12%","Portal Paladin",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","10.77%","Record Keeper",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","4.62%","Skeletal Champion",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","2.69%","Sentient Slime",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","1.35%","Harbinger of Death",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","-","16.35%","Portal Plunderer",520
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","2.94%","Sentient Slime",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","6.40%","Portal Paladin",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","10.55%","Record Keeper's Assistant",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","11.07%","Dread Knight",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","11.42%","Record Keeper",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","15.40%","Clockwork Timespinner",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","17.30%","Portal Plunderer",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","1.90%","Harbinger of Death",604
+"Bristle Woods Rift","Lucky Tower","Ancient String","Rift Antiskele","23.01%","Epoch Golem",604
+"Bristle Woods Rift","Lucky Tower","Magical String","-","13.03%","Portal Plunderer",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","22.84%","Epoch Golem",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","17.43%","Clockwork Timespinner",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","2.37%","Harbinger of Death",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","4.06%","Sentient Slime",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","4.23%","Portal Paladin",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","5.08%","Skeletal Champion",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","9.98%","Dread Knight",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","10.49%","Record Keeper",591
+"Bristle Woods Rift","Lucky Tower","Magical String","-","10.49%","Record Keeper's Assistant",591
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","17.96%","Clockwork Timespinner",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","4.31%","Sentient Slime",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","2.44%","Harbinger of Death",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","4.17%","Portal Paladin",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","9.77%","Record Keeper's Assistant",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","10.63%","Dread Knight",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","24.28%","Epoch Golem",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","14.80%","Portal Plunderer",727
+"Bristle Woods Rift","Lucky Tower","Magical String","Rift Antiskele","11.64%","Record Keeper",727
+"Bristle Woods Rift","Lucky Tower","Brie String","-","10.41%","Dread Knight",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","5.18%","Skeletal Champion",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","5.60%","Epoch Golem",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","4.31%","Portal Paladin",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","10.33%","Sentient Slime",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","20.40%","Clockwork Timespinner",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","20.24%","Portal Plunderer",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","1.52%","Harbinger of Death",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","11.02%","Record Keeper",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","-","10.98%","Record Keeper's Assistant",2632
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","21.49%","Clockwork Timespinner",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.24%","Dread Knight",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.37%","Record Keeper's Assistant",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","10.76%","Sentient Slime",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","4.58%","Portal Paladin",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","11.81%","Record Keeper",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","1.70%","Harbinger of Death",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","5.87%","Epoch Golem",3109
+"Bristle Woods Rift","Lucky Tower","Brie String","Rift Antiskele","21.18%","Portal Plunderer",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","10.97%","Record Keeper",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","10.36%","Record Keeper's Assistant",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","5.84%","Skeletal Champion",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","3.02%","Sentient Slime",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","2.11%","Harbinger of Death",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","24.65%","Epoch Golem",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","16.50%","Portal Plunderer",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","14.08%","Clockwork Timespinner",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","-","12.47%","Dread Knight",1052
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","18.04%","Portal Plunderer",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","13.75%","Dread Knight",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","25.62%","Epoch Golem",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","11.52%","Record Keeper's Assistant",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","2.05%","Harbinger of Death",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","3.30%","Sentient Slime",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","11.34%","Record Keeper",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Runic String","Rift Antiskele","14.37%","Clockwork Timespinner",1246
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","2.90%","Sentient Slime",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","1.45%","Harbinger of Death",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","24.22%","Epoch Golem",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","17.60%","Portal Plunderer",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","15.73%","Clockwork Timespinner",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","11.59%","Record Keeper",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","11.18%","Dread Knight",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","10.35%","Record Keeper's Assistant",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","-","4.97%","Skeletal Champion",520
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","11.83%","Dread Knight",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","2.03%","Harbinger of Death",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","3.14%","Sentient Slime",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","11.28%","Record Keeper's Assistant",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","24.58%","Epoch Golem",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","18.48%","Portal Plunderer",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","16.45%","Clockwork Timespinner",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Ancient String","Rift Antiskele","12.20%","Record Keeper",604
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","13.60%","Portal Plunderer",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","10.95%","Record Keeper's Assistant",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","18.20%","Clockwork Timespinner",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","23.85%","Epoch Golem",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","10.95%","Record Keeper",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","10.42%","Dread Knight",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","5.30%","Skeletal Champion",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","4.24%","Sentient Slime",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","-","2.47%","Harbinger of Death",591
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","11.09%","Dread Knight",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","2.55%","Harbinger of Death",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","4.50%","Sentient Slime",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","10.19%","Record Keeper's Assistant",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","12.14%","Record Keeper",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","15.44%","Portal Plunderer",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","18.74%","Clockwork Timespinner",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Magical String","Rift Antiskele","25.34%","Epoch Golem",727
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","1.59%","Harbinger of Death",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","10.88%","Dread Knight",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","21.31%","Clockwork Timespinner",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","21.16%","Portal Plunderer",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","11.51%","Record Keeper",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","10.80%","Sentient Slime",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","5.86%","Epoch Golem",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","11.47%","Record Keeper's Assistant",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","-","5.42%","Skeletal Champion",2632
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","22.52%","Clockwork Timespinner",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","1.78%","Harbinger of Death",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","6.15%","Epoch Golem",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.28%","Sentient Slime",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.78%","Dread Knight",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","11.92%","Record Keeper's Assistant",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","12.38%","Record Keeper",3109
+"Bristle Woods Rift","Lucky Tower (Paladin's Bane)","Brie String","Rift Antiskele","22.20%","Portal Plunderer",3109
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","5.88%","Record Keeper's Assistant",405
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","-","94.12%","Skeletal Champion",405
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","Rift Antiskele","93.18%","Record Keeper's Assistant",525
+"Bristle Woods Rift","Pursuer Mousoleum","Brie String","Rift Antiskele","6.82%","Record Keeper",525
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","-","94.12%","Skeletal Champion",405
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","-","5.88%","Record Keeper's Assistant",405
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","6.82%","Record Keeper",525
+"Bristle Woods Rift","Pursuer Mousoleum (Paladin's Bane)","Brie String","Rift Antiskele","93.18%","Record Keeper's Assistant",525
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","29.54%","Timelost Thaumaturge",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","0.32%","Sentient Slime",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","1.84%","Harbinger of Death",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","15.73%","Chamber Cleaver",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","4.34%","Skeletal Champion",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","3.95%","Portal Paladin",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","15.86%","Shackled Servant",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","6.72%","Vigilant Ward",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","10.24%","Dread Knight",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","-","11.45%","Timeslither Pythoness",4637
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","6.97%","Vigilant Ward",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","0.38%","Sentient Slime",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","10.93%","Dread Knight",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","12.03%","Timeslither Pythoness",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","16.40%","Shackled Servant",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","16.63%","Chamber Cleaver",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","30.53%","Timelost Thaumaturge",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","1.91%","Harbinger of Death",4936
+"Bristle Woods Rift","Runic Laboratory","Runic String","Rift Antiskele","4.22%","Portal Paladin",4936
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","2.15%","Harbinger of Death",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","5.20%","Skeletal Champion",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","5.47%","Portal Paladin",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","20.93%","Vigilant Ward",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","20.11%","Shackled Servant",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","10.57%","Timeslither Pythoness",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","9.50%","Sentient Slime",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","-","26.07%","Timelost Thaumaturge",15989
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","10.14%","Sentient Slime",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","21.12%","Shackled Servant",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","5.69%","Portal Paladin",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","2.33%","Harbinger of Death",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","22.11%","Vigilant Ward",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","27.51%","Timelost Thaumaturge",18104
+"Bristle Woods Rift","Runic Laboratory","Ancient String","Rift Antiskele","11.09%","Timeslither Pythoness",18104
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","4.07%","Portal Paladin",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","1.53%","Timelost Thaumaturge",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","3.56%","Harbinger of Death",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","6.36%","Skeletal Champion",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","40.97%","Sentient Slime",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","19.34%","Dread Knight",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","16.03%","Shackled Servant",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","-","8.14%","Vigilant Ward",393
+"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","3.23%","Harbinger of Death",491
+"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","41.51%","Sentient Slime",491
+"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","22.58%","Dread Knight",491
+"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","17.20%","Shackled Servant",491
+"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","9.68%","Vigilant Ward",491
+"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","1.29%","Timelost Thaumaturge",491
+"Bristle Woods Rift","Runic Laboratory","Magical String","Rift Antiskele","4.52%","Portal Paladin",491
+"Bristle Woods Rift","Runic Laboratory","Brie String","-","14.89%","Vigilant Ward",2246
+"Bristle Woods Rift","Runic Laboratory","Brie String","-","8.79%","Shackled Servant",2246
+"Bristle Woods Rift","Runic Laboratory","Brie String","-","5.16%","Portal Paladin",2246
+"Bristle Woods Rift","Runic Laboratory","Brie String","-","4.98%","Skeletal Champion",2246
+"Bristle Woods Rift","Runic Laboratory","Brie String","-","25.25%","Dread Knight",2246
+"Bristle Woods Rift","Runic Laboratory","Brie String","-","38.88%","Sentient Slime",2246
+"Bristle Woods Rift","Runic Laboratory","Brie String","-","2.06%","Harbinger of Death",2246
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","40.95%","Sentient Slime",2564
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","9.48%","Shackled Servant",2564
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","15.26%","Vigilant Ward",2564
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","2.31%","Harbinger of Death",2564
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","6.10%","Portal Paladin",2564
+"Bristle Woods Rift","Runic Laboratory","Brie String","Rift Antiskele","25.90%","Dread Knight",2564
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","1.76%","Portal Paladin",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","5.29%","Skeletal Champion",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","18.24%","Vigilant Ward",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","24.12%","Dread Knight",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","42.94%","Sentient Slime",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","4.12%","Shackled Servant",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","-","3.53%","Harbinger of Death",170
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","25.15%","Dread Knight",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","1.84%","Portal Paladin",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","3.68%","Harbinger of Death",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","4.29%","Shackled Servant",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","19.02%","Vigilant Ward",172
+"Bristle Woods Rift","Runic Laboratory","Swiss String","Rift Antiskele","46.01%","Sentient Slime",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","0.34%","Sentient Slime",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","1.91%","Harbinger of Death",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","7.00%","Vigilant Ward",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","10.66%","Dread Knight",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","4.52%","Skeletal Champion",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","11.92%","Timeslither Pythoness",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","16.38%","Chamber Cleaver",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","16.51%","Shackled Servant",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","-","30.75%","Timelost Thaumaturge",4637
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","31.87%","Timelost Thaumaturge",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","0.40%","Sentient Slime",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","1.99%","Harbinger of Death",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","7.28%","Vigilant Ward",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","11.41%","Dread Knight",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","17.36%","Chamber Cleaver",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","17.12%","Shackled Servant",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Runic String","Rift Antiskele","12.56%","Timeslither Pythoness",4936
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","27.58%","Timelost Thaumaturge",15989
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","22.14%","Vigilant Ward",15989
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","21.28%","Shackled Servant",15989
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","11.18%","Timeslither Pythoness",15989
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","5.50%","Skeletal Champion",15989
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","10.05%","Sentient Slime",15989
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","-","2.27%","Harbinger of Death",15989
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","29.17%","Timelost Thaumaturge",18104
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","2.48%","Harbinger of Death",18104
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","10.75%","Sentient Slime",18104
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","11.76%","Timeslither Pythoness",18104
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","22.39%","Shackled Servant",18104
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Ancient String","Rift Antiskele","23.44%","Vigilant Ward",18104
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","6.63%","Skeletal Champion",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","8.49%","Vigilant Ward",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","16.71%","Shackled Servant",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","42.71%","Sentient Slime",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","20.16%","Dread Knight",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","1.59%","Timelost Thaumaturge",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","-","3.71%","Harbinger of Death",393
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","23.65%","Dread Knight",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","1.35%","Timelost Thaumaturge",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","3.38%","Harbinger of Death",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","10.14%","Vigilant Ward",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","18.02%","Shackled Servant",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Magical String","Rift Antiskele","43.47%","Sentient Slime",491
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","9.27%","Shackled Servant",2246
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","5.25%","Skeletal Champion",2246
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","2.17%","Harbinger of Death",2246
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","40.99%","Sentient Slime",2246
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","26.62%","Dread Knight",2246
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","-","15.70%","Vigilant Ward",2246
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","10.10%","Shackled Servant",2564
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","2.46%","Harbinger of Death",2564
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","43.61%","Sentient Slime",2564
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","27.58%","Dread Knight",2564
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Brie String","Rift Antiskele","16.25%","Vigilant Ward",2564
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","3.59%","Harbinger of Death",170
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","43.71%","Sentient Slime",170
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","18.56%","Vigilant Ward",170
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","5.39%","Skeletal Champion",170
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","4.19%","Shackled Servant",170
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","-","24.55%","Dread Knight",170
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","25.62%","Dread Knight",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","3.75%","Harbinger of Death",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","4.38%","Shackled Servant",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","19.38%","Vigilant Ward",172
+"Bristle Woods Rift","Runic Laboratory (Paladin's Bane)","Swiss String","Rift Antiskele","46.88%","Sentient Slime",172
+"Bristle Woods Rift","Security","Runic String","-","91.70%","Skeletal Champion",255
+"Bristle Woods Rift","Security","Runic String","-","7.11%","Timelost Thaumaturge",255
+"Bristle Woods Rift","Security","Runic String","-","0.79%","Shackled Servant",255
+"Bristle Woods Rift","Security","Runic String","-","0.40%","Vigilant Ward",255
+"Bristle Woods Rift","Security","Runic String","Rift Antiskele","19.35%","Shackled Servant",269
+"Bristle Woods Rift","Security","Runic String","Rift Antiskele","77.42%","Timelost Thaumaturge",269
+"Bristle Woods Rift","Security","Runic String","Rift Antiskele","3.23%","Vigilant Ward",269
+"Bristle Woods Rift","Security","Ancient String","-","1.68%","Shackled Servant",179
+"Bristle Woods Rift","Security","Ancient String","-","1.12%","Vigilant Ward",179
+"Bristle Woods Rift","Security","Ancient String","-","91.06%","Skeletal Champion",179
+"Bristle Woods Rift","Security","Ancient String","-","6.15%","Timelost Thaumaturge",179
+"Bristle Woods Rift","Security","Ancient String","Rift Antiskele","24.14%","Shackled Servant",208
+"Bristle Woods Rift","Security","Ancient String","Rift Antiskele","13.79%","Vigilant Ward",208
+"Bristle Woods Rift","Security","Ancient String","Rift Antiskele","62.07%","Timelost Thaumaturge",208
+"Bristle Woods Rift","Security","Magical String","-","5.83%","Timelost Thaumaturge",120
+"Bristle Woods Rift","Security","Magical String","-","91.67%","Skeletal Champion",120
+"Bristle Woods Rift","Security","Magical String","-","1.67%","Vigilant Ward",120
+"Bristle Woods Rift","Security","Magical String","-","0.83%","Shackled Servant",120
+"Bristle Woods Rift","Security","Magical String","Rift Antiskele","17.65%","Vigilant Ward",144
+"Bristle Woods Rift","Security","Magical String","Rift Antiskele","76.47%","Timelost Thaumaturge",144
+"Bristle Woods Rift","Security","Magical String","Rift Antiskele","5.88%","Shackled Servant",144
+"Bristle Woods Rift","Security","Brie String","-","4.21%","Vigilant Ward",913
+"Bristle Woods Rift","Security","Brie String","-","1.88%","Shackled Servant",913
+"Bristle Woods Rift","Security","Brie String","-","90.58%","Skeletal Champion",913
+"Bristle Woods Rift","Security","Brie String","-","3.33%","Timelost Thaumaturge",913
+"Bristle Woods Rift","Security","Brie String","Rift Antiskele","37.76%","Vigilant Ward",1170
+"Bristle Woods Rift","Security","Brie String","Rift Antiskele","20.92%","Shackled Servant",1170
+"Bristle Woods Rift","Security","Brie String","Rift Antiskele","41.33%","Timelost Thaumaturge",1170
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","0.40%","Vigilant Ward",255
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","0.79%","Shackled Servant",255
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","7.11%","Timelost Thaumaturge",255
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","-","91.70%","Skeletal Champion",255
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","Rift Antiskele","3.23%","Vigilant Ward",269
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","Rift Antiskele","77.42%","Timelost Thaumaturge",269
+"Bristle Woods Rift","Security (Paladin's Bane)","Runic String","Rift Antiskele","19.35%","Shackled Servant",269
+"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","-","91.06%","Skeletal Champion",179
+"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","-","1.68%","Shackled Servant",179
+"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","-","6.15%","Timelost Thaumaturge",179
+"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","-","1.12%","Vigilant Ward",179
+"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","Rift Antiskele","24.14%","Shackled Servant",208
+"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","Rift Antiskele","62.07%","Timelost Thaumaturge",208
+"Bristle Woods Rift","Security (Paladin's Bane)","Ancient String","Rift Antiskele","13.79%","Vigilant Ward",208
+"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","1.67%","Vigilant Ward",120
+"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","0.83%","Shackled Servant",120
+"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","5.83%","Timelost Thaumaturge",120
+"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","-","91.67%","Skeletal Champion",120
+"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","Rift Antiskele","76.47%","Timelost Thaumaturge",144
+"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","Rift Antiskele","17.65%","Vigilant Ward",144
+"Bristle Woods Rift","Security (Paladin's Bane)","Magical String","Rift Antiskele","5.88%","Shackled Servant",144
+"Bristle Woods Rift","Security (Paladin's Bane)","Brie String","-","4.21%","Vigilant Ward",913
+"Bristle Woods Rift","Security (Paladin's Bane)","Brie String","-","3.33%","Timelost Thaumaturge",913
+"Bristle Woods Rift","Security (Paladin's Bane)","Brie String","-","1.88%","Shackled Servant",913
+"Bristle Woods Rift","Security (Paladin's Bane)","Brie String","-","90.58%","Skeletal Champion",913
+"Bristle Woods Rift","Security (Paladin's Bane)","Brie String","Rift Antiskele","41.33%","Timelost Thaumaturge",1170
+"Bristle Woods Rift","Security (Paladin's Bane)","Brie String","Rift Antiskele","37.76%","Vigilant Ward",1170
+"Bristle Woods Rift","Security (Paladin's Bane)","Brie String","Rift Antiskele","20.92%","Shackled Servant",1170
+"Bristle Woods Rift","Timewarp","Runic String","-","33.83%","Carrion Medium",36410
+"Bristle Woods Rift","Timewarp","Runic String","-","5.36%","Skeletal Champion",36410
+"Bristle Woods Rift","Timewarp","Runic String","-","19.17%","Timeless Lich",36410
+"Bristle Woods Rift","Timewarp","Runic String","-","10.24%","Sentient Slime",36410
+"Bristle Woods Rift","Timewarp","Runic String","-","26.26%","Chronomaster",36410
+"Bristle Woods Rift","Timewarp","Runic String","-","5.15%","Portal Paladin",36410
+"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","20.18%","Timeless Lich",43160
+"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","10.92%","Sentient Slime",43160
+"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","27.71%","Chronomaster",43160
+"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","35.77%","Carrion Medium",43160
+"Bristle Woods Rift","Timewarp","Runic String","Rift Antiskele","5.42%","Portal Paladin",43160
+"Bristle Woods Rift","Timewarp","Ancient String","-","15.82%","Timeless Lich",792
+"Bristle Woods Rift","Timewarp","Ancient String","-","5.87%","Skeletal Champion",792
+"Bristle Woods Rift","Timewarp","Ancient String","-","4.97%","Portal Paladin",792
+"Bristle Woods Rift","Timewarp","Ancient String","-","30.48%","Dread Knight",792
+"Bristle Woods Rift","Timewarp","Ancient String","-","26.28%","Sentient Slime",792
+"Bristle Woods Rift","Timewarp","Ancient String","-","16.58%","Carrion Medium",792
+"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","17.45%","Timeless Lich",906
+"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","5.66%","Portal Paladin",906
+"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","17.33%","Carrion Medium",906
+"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","32.08%","Dread Knight",906
+"Bristle Woods Rift","Timewarp","Ancient String","Rift Antiskele","27.48%","Sentient Slime",906
+"Bristle Woods Rift","Timewarp","Magical String","-","11.05%","Carrion Medium",344
+"Bristle Woods Rift","Timewarp","Magical String","-","6.40%","Skeletal Champion",344
+"Bristle Woods Rift","Timewarp","Magical String","-","33.72%","Dread Knight",344
+"Bristle Woods Rift","Timewarp","Magical String","-","40.41%","Sentient Slime",344
+"Bristle Woods Rift","Timewarp","Magical String","-","4.94%","Portal Paladin",344
+"Bristle Woods Rift","Timewarp","Magical String","-","3.49%","Timeless Lich",344
+"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","3.76%","Timeless Lich",369
+"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","5.20%","Portal Paladin",369
+"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","12.14%","Carrion Medium",369
+"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","42.49%","Sentient Slime",369
+"Bristle Woods Rift","Timewarp","Magical String","Rift Antiskele","36.42%","Dread Knight",369
+"Bristle Woods Rift","Timewarp","Brie String","-","41.16%","Dread Knight",1743
+"Bristle Woods Rift","Timewarp","Brie String","-","8.03%","Carrion Medium",1743
+"Bristle Woods Rift","Timewarp","Brie String","-","2.20%","Timeless Lich",1743
+"Bristle Woods Rift","Timewarp","Brie String","-","4.22%","Portal Paladin",1743
+"Bristle Woods Rift","Timewarp","Brie String","-","38.21%","Sentient Slime",1743
+"Bristle Woods Rift","Timewarp","Brie String","-","6.18%","Skeletal Champion",1743
+"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","8.45%","Carrion Medium",1929
+"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","41.13%","Sentient Slime",1929
+"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","43.41%","Dread Knight",1929
+"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","2.33%","Timeless Lich",1929
+"Bristle Woods Rift","Timewarp","Brie String","Rift Antiskele","4.67%","Portal Paladin",1929
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","27.68%","Chronomaster",36410
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","20.21%","Timeless Lich",36410
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","10.79%","Sentient Slime",36410
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","5.65%","Skeletal Champion",36410
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","-","35.66%","Carrion Medium",36410
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","Rift Antiskele","37.82%","Carrion Medium",43160
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","Rift Antiskele","21.33%","Timeless Lich",43160
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","Rift Antiskele","11.54%","Sentient Slime",43160
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Runic String","Rift Antiskele","29.30%","Chronomaster",43160
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","32.08%","Dread Knight",792
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","27.65%","Sentient Slime",792
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","17.45%","Carrion Medium",792
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","16.64%","Timeless Lich",792
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","-","6.17%","Skeletal Champion",792
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","Rift Antiskele","29.13%","Sentient Slime",906
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","Rift Antiskele","18.50%","Timeless Lich",906
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","Rift Antiskele","18.38%","Carrion Medium",906
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Ancient String","Rift Antiskele","34.00%","Dread Knight",906
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","35.47%","Dread Knight",344
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","6.73%","Skeletal Champion",344
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","3.67%","Timeless Lich",344
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","42.51%","Sentient Slime",344
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","-","11.62%","Carrion Medium",344
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","Rift Antiskele","44.82%","Sentient Slime",369
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","Rift Antiskele","38.41%","Dread Knight",369
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","Rift Antiskele","12.80%","Carrion Medium",369
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Magical String","Rift Antiskele","3.96%","Timeless Lich",369
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","39.89%","Sentient Slime",1743
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","8.39%","Carrion Medium",1743
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","6.46%","Skeletal Champion",1743
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","2.29%","Timeless Lich",1743
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","-","42.97%","Dread Knight",1743
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","8.86%","Carrion Medium",1929
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","2.45%","Timeless Lich",1929
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","45.54%","Dread Knight",1929
+"Bristle Woods Rift","Timewarp (Paladin's Bane)","Brie String","Rift Antiskele","43.15%","Sentient Slime",1929

--- a/src/bookmarklet/crebookmarklet.js
+++ b/src/bookmarklet/crebookmarklet.js
@@ -270,7 +270,11 @@
         return "Training Grounds";
       }
     } else if (userLocation === "Bristle Woods Rift") {
-      return userQuests["QuestRiftBristleWoods"]["chamber_name"];
+      var chamber = userQuests["QuestRiftBristleWoods"]["chamber_name"];
+      if (userQuests["QuestRiftBristleWoods"]["status_effects"]["ng"] === 'active') {
+        return chamber + " (Paladin's Bane)";
+      }
+      return chamber
     } else if (userLocation === "Zugzwang's Tower") {
       var mystic = userViewingAtts["zzt_mage_progress"];
       var tech = userViewingAtts["zzt_tech_progress"];

--- a/tools/bwriftpop.js
+++ b/tools/bwriftpop.js
@@ -2,6 +2,7 @@
 
 var jt = require("jacksmhtools-client");
 var utils = require("./_utils");
+var paladinBaneSuffix = ' (Paladin\'s Bane)'
 var stages = [
   "Acolyte",
   "Ancient Lab",
@@ -26,6 +27,16 @@ var cheeses = [
   "Swiss String",
   "Marble String"
 ]
+// Stages where Portal Pursuer is always available or Paladin's Bane have no effect
+var specialStages = [
+  "Entrance",
+  'Guard Barracks',
+  "Ingress",
+  "Pursuer Mousoleum",
+  "Security"
+]
+
+var normalStages = stages.filter(function (stage) { return specialStages.indexOf(stage) === -1})
 
 utils
   .process({
@@ -34,8 +45,8 @@ utils
       cheese: utils.genVarField("cheese", cheeses),
     },
     series: [
-      { // normal
-        phase: utils.genVarField("stage", stages),
+      { // normal chambers - no pursuer and no paladin's bane
+        phase: utils.genVarField("stage", normalStages),
         charm: [
           {
             vars: { charm: { "Rift Antiskele": false } },
@@ -47,9 +58,9 @@ utils
           }
         ]
       },
-      { // with Paladin's Bane buff
-        phase: utils.genVarField("stage", stages).map(function (options) {
-          options.fields.stage += ' (Paladin\'s Bane)'
+      { // normal chambers with Paladin's Bane buff
+        phase: utils.genVarField("stage", normalStages).map(function (options) {
+          options.fields.stage += paladinBaneSuffix
           return options
         }),
         charm: [
@@ -60,6 +71,75 @@ utils
           {
             fields: { charm: "Rift Antiskele" },
             opts: { exclude: [ 'Skeletal Champion', 'Portal Pursuer', 'Portal Paladin' ] }
+          }
+        ]
+      },
+      { // Entrance - have no buffs or curses
+        phase: utils.genVarField("stage", "Entrance"),
+        charm: [
+          {
+            vars: { charm: { "Rift Antiskele": false } },
+            opts: { exclude: [ 'Portal Pursuer' ] }
+          },
+          {
+            fields: { charm: "Rift Antiskele" },
+            opts: { exclude: [ 'Skeletal Champion', 'Portal Pursuer' ] }
+          }
+        ]
+      },
+      { // Guard Barracks - no paladin's bane and no skeletal champion
+        phase: utils.genVarField("stage", "Guard Barracks"),
+        noPursuer: [ { opts: { exclude: [ 'Portal Pursuer' ] } } ]
+      },
+      { // Ingress chamber - have Portal Pursuer but no Skeletal Champion
+        phase: [
+          {
+            vars: { stage: { "Ingress": true } },
+            fields: { stage: "Ingress" }
+          },
+          {
+            vars: { stage: { "Ingress": true } },
+            fields: { stage: "Ingress" + paladinBaneSuffix },
+            opts: { exclude: [ 'Portal Paladin' ] }
+          }
+        ]
+      },
+      { // Pursuer Mousoleum without paladin's bane - have Portal Pursuer
+        phase: utils.genVarField("stage", "Pursuer Mousoleum"),
+        charm: [
+          { vars: { charm: { "Rift Antiskele": false } } },
+          {
+            fields: { charm: "Rift Antiskele" },
+            opts: { exclude: [ 'Skeletal Champion' ] }
+          }
+        ]
+      },
+      { // Pursuer Mousoleum with paladin's bane - have Portal Pursuer
+        phase: [{
+          vars: { stage: { "Pursuer Mousoleum": true } },
+          fields: { stage: "Pursuer Mousoleum" + paladinBaneSuffix }
+        }],
+        charm: [
+          { vars: { charm: { "Rift Antiskele": false } } },
+          {
+            fields: { charm: "Rift Antiskele" },
+            opts: { exclude: [ 'Skeletal Champion', 'Portal Paladin' ] }
+          }
+        ]
+      },
+      { // Security Chamber - always with paladin's bane
+        phase: [{
+          vars: { stage: { "Security": true } },
+          fields: { stage: "Security" + paladinBaneSuffix }
+        }],
+        charm: [
+          {
+            vars: { charm: { "Rift Antiskele": false } },
+            opts: { exclude: [ 'Portal Pursuer' ] }
+          },
+          {
+            fields: { charm: "Rift Antiskele" },
+            opts: { exclude: [ 'Skeletal Champion', 'Portal Pursuer' ] }
           }
         ]
       }

--- a/tools/bwriftpop.js
+++ b/tools/bwriftpop.js
@@ -2,54 +2,92 @@
 
 var jt = require("jacksmhtools-client");
 var utils = require("./_utils");
+var stages = [
+  "Acolyte",
+  "Ancient Lab",
+  "Entrance",
+  "Frozen Alcove",
+  "Furnace Room",
+  "Gearworks",
+  "Guard Barracks",
+  "Hidden Treasury",
+  "Ingress",
+  "Lucky Tower",
+  "Pursuer Mousoleum",
+  "Runic Laboratory",
+  "Security",
+  "Timewarp"
+]
+var cheeses = [
+  "Runic String",
+  "Ancient String",
+  "Magical String",
+  "Brie String",
+  "Swiss String",
+  "Marble String"
+]
 
 utils
   .process({
-    default: {},
+    default: {
+      location: utils.genVarField("location", "Bristle Woods Rift"),
+      cheese: utils.genVarField("cheese", cheeses),
+    },
     series: [
-      {
-        location: utils.genVarField("location", "Bristle Woods Rift"),
-        phase: utils.genVarField("stage", [
-          "Acolyte",
-          "Ancient Lab",
-          "Entrance",
-          "Frozen Alcove",
-          "Furnace Room",
-          "Gearworks",
-          "Guard Barracks",
-          "Hidden Treasury",
-          "Ingress",
-          "Lucky Tower",
-          "Pursuer Mousoleum",
-          "Runic Laboratory",
-          "Security",
-          "Timewarp"
-        ]),
-        cheese: utils.genVarField("cheese", [
-          "Runic String",
-          "Ancient String",
-          "Magical String",
-          "Brie String",
-          "Swiss String"
-        ]),
+      { // normal
+        phase: utils.genVarField("stage", stages),
         charm: [
-          { vars: { charm: { "Rift Antiskele": false } } },
           {
-            vars: { charm: { "Rift Antiskele": true } },
-            fields: { charm: "Rift Antiskele" }
+            vars: { charm: { "Rift Antiskele": false } },
+            opts: { exclude: [ 'Portal Pursuer' ] }
+          },
+          {
+            fields: { charm: "Rift Antiskele" },
+            opts: { exclude: [ 'Skeletal Champion', 'Portal Pursuer' ] }
+          }
+        ]
+      },
+      { // with Paladin's Bane buff
+        phase: utils.genVarField("stage", stages).map(function (options) {
+          options.fields.stage += ' (Paladin\'s Bane)'
+          return options
+        }),
+        charm: [
+          {
+            vars: { charm: { "Rift Antiskele": false } },
+            opts: { exclude: [ 'Portal Pursuer', 'Portal Paladin' ] }
+          },
+          {
+            fields: { charm: "Rift Antiskele" },
+            opts: { exclude: [ 'Skeletal Champion', 'Portal Pursuer', 'Portal Paladin' ] }
           }
         ]
       }
     ],
-    process: function(item) {
+    process: function (item) {
       console.error("requesting", JSON.stringify(item.vars));
       return jt
         .getSAEncounterRateData(item.vars, item.opts)
-        .filter(function(item) {
+        .filter(function (item) {
           return item.sample > 100;
         })
         .map(utils.preparePopulation.bind(utils, item.fields));
     }
+  })
+  .then(function (rows) {
+    return rows.sort(function (a, b) {
+      if (a.stage < b.stage) return -1
+      if (a.stage > b.stage) return 1
+      var cheeseA = cheeses.indexOf(a.cheese)
+      var cheeseB = cheeses.indexOf(b.cheese)
+      if (cheeseA < cheeseB) return -1
+      if (cheeseA > cheeseB) return 1
+      var charmA = a.charm || '-'
+      var charmB = b.charm || '-'
+      if (charmA < charmB) return -1
+      if (charmA > charmB) return 1
+      return 0
+    })
   })
   .then(utils.toCsv.bind(utils, utils.POP_FIELDS))
   .then(console.log.bind(console));

--- a/tools/bwriftpop.js
+++ b/tools/bwriftpop.js
@@ -86,6 +86,8 @@ utils
       var charmB = b.charm || '-'
       if (charmA < charmB) return -1
       if (charmA > charmB) return 1
+      if (parseFloat(a.attraction) > parseFloat(b.attraction)) return -1
+      if (parseFloat(a.attraction) < parseFloat(b.attraction)) return 1
       return 0
     })
   })


### PR DESCRIPTION
Antiskele population is computed from general population with removed Skeletal Champion.
Paladin's Bane population is computed from general population with removed Portal Paladin.

CRE bookmarklet is updated to support PB population phase.

Data is extracted from Sat Feb 3 07:56:28 2018 +0000 nightly backup