### PR TITLE
Updated population data from Jack's 15 May 2019 DB 

### DIFF
--- a/data/pop-csv/acolyte-realm.csv
+++ b/data/pop-csv/acolyte-realm.csv
@@ -1,21 +1,21 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Acolyte Realm","-","Runic","-","19.33%","Golem",37174
-"Acolyte Realm","-","Runic","-","18.70%","Gorgon",37174
-"Acolyte Realm","-","Runic","-","17.93%","Spectre",37174
-"Acolyte Realm","-","Runic","-","16.15%","Sorcerer",37174
-"Acolyte Realm","-","Runic","-","8.22%","Wight",37174
-"Acolyte Realm","-","Runic","-","8.11%","Lich",37174
-"Acolyte Realm","-","Runic","-","8.10%","Acolyte",37174
-"Acolyte Realm","-","Runic","-","2.08%","Chrono",37174
-"Acolyte Realm","-","Runic","-","1.39%","Gate Guardian",37174
-"Acolyte Realm","-","Ancient","-","26.34%","Golem",3706
-"Acolyte Realm","-","Ancient","-","25.15%","Spectre",3706
-"Acolyte Realm","-","Ancient","-","20.78%","Gorgon",3706
-"Acolyte Realm","-","Ancient","-","20.40%","Sorcerer",3706
-"Acolyte Realm","-","Ancient","-","7.34%","Gate Guardian",3706
-"Acolyte Realm","-","Radioactive Blue","-","33.55%","Gate Guardian",2420
-"Acolyte Realm","-","Radioactive Blue","-","33.47%","Golem",2420
-"Acolyte Realm","-","Radioactive Blue","-","12.93%","Mutated Grey",2420
-"Acolyte Realm","-","Radioactive Blue","-","12.48%","Mutated White",2420
-"Acolyte Realm","-","Radioactive Blue","-","7.19%","Mutated Brown",2420
-"Acolyte Realm","-","Radioactive Blue","-","0.37%","Black Widow",2420
+"Acolyte Realm","-","Runic","-","19.35%","Golem",43174
+"Acolyte Realm","-","Runic","-","18.65%","Gorgon",43174
+"Acolyte Realm","-","Runic","-","17.79%","Spectre",43174
+"Acolyte Realm","-","Runic","-","16.26%","Sorcerer",43174
+"Acolyte Realm","-","Runic","-","8.21%","Wight",43174
+"Acolyte Realm","-","Runic","-","8.18%","Acolyte",43174
+"Acolyte Realm","-","Runic","-","8.12%","Lich",43174
+"Acolyte Realm","-","Runic","-","2.04%","Chrono",43174
+"Acolyte Realm","-","Runic","-","1.41%","Gate Guardian",43174
+"Acolyte Realm","-","Ancient","-","26.06%","Golem",4029
+"Acolyte Realm","-","Ancient","-","25.22%","Spectre",4029
+"Acolyte Realm","-","Ancient","-","20.80%","Gorgon",4029
+"Acolyte Realm","-","Ancient","-","20.65%","Sorcerer",4029
+"Acolyte Realm","-","Ancient","-","7.27%","Gate Guardian",4029
+"Acolyte Realm","-","Radioactive Blue","-","33.53%","Gate Guardian",2887
+"Acolyte Realm","-","Radioactive Blue","-","33.46%","Golem",2887
+"Acolyte Realm","-","Radioactive Blue","-","13.13%","Mutated Grey",2887
+"Acolyte Realm","-","Radioactive Blue","-","12.61%","Mutated White",2887
+"Acolyte Realm","-","Radioactive Blue","-","6.89%","Mutated Brown",2887
+"Acolyte Realm","-","Radioactive Blue","-","0.38%","Black Widow",2887

--- a/data/pop-csv/cantera-quarry.csv
+++ b/data/pop-csv/cantera-quarry.csv
@@ -1,10 +1,10 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Cantera Quarry","-","Bland Queso","-","60.84%","Chip Chiseler",9250
-"Cantera Quarry","-","Bland Queso","-","39.16%","Tiny Toppler",9250
-"Cantera Quarry","-","Mild Queso","-","50.07%","Rubble Rummager",11784
-"Cantera Quarry","-","Mild Queso","-","49.93%","Ore Chipper",11784
-"Cantera Quarry","-","Medium Queso","-","60.99%","Nachore Golem",13296
-"Cantera Quarry","-","Medium Queso","-","39.01%","Rubble Rouser",13296
-"Cantera Quarry","-","Hot Queso","-","50.75%","Grampa Golem",20776
-"Cantera Quarry","-","Hot Queso","-","49.25%","Fiery Crusher",20776
-"Cantera Quarry","-","Flamin' Queso","-","100.00%","Nachous, The Molten",9354
+"Cantera Quarry","-","Bland Queso","-","60.30%","Chip Chiseler",12578
+"Cantera Quarry","-","Bland Queso","-","39.70%","Tiny Toppler",12578
+"Cantera Quarry","-","Mild Queso","-","50.27%","Ore Chipper",14509
+"Cantera Quarry","-","Mild Queso","-","49.73%","Rubble Rummager",14509
+"Cantera Quarry","-","Medium Queso","-","60.77%","Nachore Golem",16967
+"Cantera Quarry","-","Medium Queso","-","39.23%","Rubble Rouser",16967
+"Cantera Quarry","-","Hot Queso","-","50.85%","Grampa Golem",27395
+"Cantera Quarry","-","Hot Queso","-","49.15%","Fiery Crusher",27395
+"Cantera Quarry","-","Flamin' Queso","-","100.00%","Nachous, The Molten",20032

--- a/data/pop-csv/catacombs.csv
+++ b/data/pop-csv/catacombs.csv
@@ -1,80 +1,80 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Catacombs","-","Radioactive Blue","-","16.00%","Skeleton",14360
-"Catacombs","-","Radioactive Blue","-","14.21%","Ghost",14360
-"Catacombs","-","Radioactive Blue","-","9.03%","Ooze",14360
-"Catacombs","-","Radioactive Blue","-","8.80%","Spider",14360
-"Catacombs","-","Radioactive Blue","-","8.65%","Scavenger",14360
-"Catacombs","-","Radioactive Blue","-","7.89%","Keeper's Assistant",14360
-"Catacombs","-","Radioactive Blue","-","6.87%","Giant Snail",14360
-"Catacombs","-","Radioactive Blue","-","6.39%","Mummy",14360
-"Catacombs","-","Radioactive Blue","-","4.54%","Terror Knight",14360
-"Catacombs","-","Radioactive Blue","-","4.28%","Vampire",14360
-"Catacombs","-","Radioactive Blue","-","4.06%","Zombie",14360
-"Catacombs","-","Radioactive Blue","-","3.38%","Bat",14360
-"Catacombs","-","Radioactive Blue","-","2.59%","Golem",14360
-"Catacombs","-","Radioactive Blue","-","1.62%","Keeper",14360
-"Catacombs","-","Radioactive Blue","-","0.88%","Lycan",14360
-"Catacombs","-","Radioactive Blue","-","0.44%","Monster",14360
-"Catacombs","-","Radioactive Blue","-","0.24%","Gluttonous Zombie",14360
-"Catacombs","-","Radioactive Blue","-","0.14%","Black Widow",14360
-"Catacombs","-","Ancient","-","16.84%","Skeleton",8266
-"Catacombs","-","Ancient","-","14.23%","Spider",8266
-"Catacombs","-","Ancient","-","14.19%","Ooze",8266
-"Catacombs","-","Ancient","-","13.34%","Scavenger",8266
-"Catacombs","-","Ancient","-","13.02%","Keeper's Assistant",8266
-"Catacombs","-","Ancient","-","12.03%","Keeper",8266
-"Catacombs","-","Ancient","-","7.14%","Terror Knight",8266
-"Catacombs","-","Ancient","-","4.75%","Vampire",8266
-"Catacombs","-","Ancient","-","4.46%","Golem",8266
-"Catacombs","-","Moon","-","46.60%","Lycan",779
-"Catacombs","-","Moon","-","18.49%","Scavenger",779
-"Catacombs","-","Moon","-","10.65%","Ghost",779
-"Catacombs","-","Moon","-","6.68%","Mummy",779
-"Catacombs","-","Moon","-","6.42%","Bat",779
-"Catacombs","-","Moon","-","5.65%","Zombie",779
-"Catacombs","-","Moon","-","5.13%","Vampire",779
-"Catacombs","-","Moon","-","0.39%","Gluttonous Zombie",779
-"Catacombs","-","Undead Emmental","-","16.89%","Mummy",1978
-"Catacombs","-","Undead Emmental","-","14.46%","Ghost",1978
-"Catacombs","-","Undead Emmental","-","13.80%","Grave Robber",1978
-"Catacombs","-","Undead Emmental","-","11.43%","Vampire",1978
-"Catacombs","-","Undead Emmental","-","10.92%","Zombot Unipire",1978
-"Catacombs","-","Undead Emmental","-","10.16%","Skeleton",1978
-"Catacombs","-","Undead Emmental","-","8.54%","Terror Knight",1978
-"Catacombs","-","Undead Emmental","-","7.68%","Ravenous Zombie",1978
-"Catacombs","-","Undead Emmental","-","3.59%","Zombie",1978
-"Catacombs","-","Undead Emmental","-","2.53%","Gluttonous Zombie",1978
-"Catacombs","-","Radioactive Blue","Antiskele","16.53%","Ghost",1416
-"Catacombs","-","Radioactive Blue","Antiskele","10.88%","Ooze",1416
-"Catacombs","-","Radioactive Blue","Antiskele","10.73%","Keeper's Assistant",1416
-"Catacombs","-","Radioactive Blue","Antiskele","9.96%","Spider",1416
-"Catacombs","-","Radioactive Blue","Antiskele","9.89%","Scavenger",1416
-"Catacombs","-","Radioactive Blue","Antiskele","9.18%","Giant Snail",1416
-"Catacombs","-","Radioactive Blue","Antiskele","6.92%","Mummy",1416
-"Catacombs","-","Radioactive Blue","Antiskele","5.01%","Vampire",1416
-"Catacombs","-","Radioactive Blue","Antiskele","4.66%","Terror Knight",1416
-"Catacombs","-","Radioactive Blue","Antiskele","4.38%","Zombie",1416
-"Catacombs","-","Radioactive Blue","Antiskele","4.24%","Bat",1416
-"Catacombs","-","Radioactive Blue","Antiskele","3.25%","Golem",1416
-"Catacombs","-","Radioactive Blue","Antiskele","2.54%","Keeper",1416
-"Catacombs","-","Radioactive Blue","Antiskele","0.92%","Lycan",1416
-"Catacombs","-","Radioactive Blue","Antiskele","0.49%","Monster",1416
-"Catacombs","-","Radioactive Blue","Antiskele","0.28%","Gluttonous Zombie",1416
-"Catacombs","-","Radioactive Blue","Antiskele","0.14%","Black Widow",1416
-"Catacombs","-","Ancient","Antiskele","18.55%","Spider",3995
-"Catacombs","-","Ancient","Antiskele","17.87%","Ooze",3995
-"Catacombs","-","Ancient","Antiskele","16.22%","Keeper's Assistant",3995
-"Catacombs","-","Ancient","Antiskele","14.44%","Scavenger",3995
-"Catacombs","-","Ancient","Antiskele","13.87%","Keeper",3995
-"Catacombs","-","Ancient","Antiskele","8.61%","Terror Knight",3995
-"Catacombs","-","Ancient","Antiskele","5.36%","Golem",3995
-"Catacombs","-","Ancient","Antiskele","5.08%","Vampire",3995
-"Catacombs","-","Undead Emmental","Antiskele","20.55%","Mummy",1888
-"Catacombs","-","Undead Emmental","Antiskele","16.79%","Ghost",1888
-"Catacombs","-","Undead Emmental","Antiskele","15.36%","Grave Robber",1888
-"Catacombs","-","Undead Emmental","Antiskele","11.65%","Zombot Unipire",1888
-"Catacombs","-","Undead Emmental","Antiskele","10.81%","Vampire",1888
-"Catacombs","-","Undead Emmental","Antiskele","10.65%","Terror Knight",1888
-"Catacombs","-","Undead Emmental","Antiskele","7.42%","Ravenous Zombie",1888
-"Catacombs","-","Undead Emmental","Antiskele","4.77%","Zombie",1888
-"Catacombs","-","Undead Emmental","Antiskele","2.01%","Gluttonous Zombie",1888
+"Catacombs","-","Radioactive Blue","-","16.00%","Skeleton",14413
+"Catacombs","-","Radioactive Blue","-","14.21%","Ghost",14413
+"Catacombs","-","Radioactive Blue","-","9.03%","Ooze",14413
+"Catacombs","-","Radioactive Blue","-","8.84%","Spider",14413
+"Catacombs","-","Radioactive Blue","-","8.64%","Scavenger",14413
+"Catacombs","-","Radioactive Blue","-","7.87%","Keeper's Assistant",14413
+"Catacombs","-","Radioactive Blue","-","6.85%","Giant Snail",14413
+"Catacombs","-","Radioactive Blue","-","6.39%","Mummy",14413
+"Catacombs","-","Radioactive Blue","-","4.53%","Terror Knight",14413
+"Catacombs","-","Radioactive Blue","-","4.26%","Vampire",14413
+"Catacombs","-","Radioactive Blue","-","4.08%","Zombie",14413
+"Catacombs","-","Radioactive Blue","-","3.38%","Bat",14413
+"Catacombs","-","Radioactive Blue","-","2.58%","Golem",14413
+"Catacombs","-","Radioactive Blue","-","1.62%","Keeper",14413
+"Catacombs","-","Radioactive Blue","-","0.89%","Lycan",14413
+"Catacombs","-","Radioactive Blue","-","0.44%","Monster",14413
+"Catacombs","-","Radioactive Blue","-","0.25%","Gluttonous Zombie",14413
+"Catacombs","-","Radioactive Blue","-","0.14%","Black Widow",14413
+"Catacombs","-","Ancient","-","16.83%","Skeleton",8287
+"Catacombs","-","Ancient","-","14.23%","Spider",8287
+"Catacombs","-","Ancient","-","14.22%","Ooze",8287
+"Catacombs","-","Ancient","-","13.32%","Scavenger",8287
+"Catacombs","-","Ancient","-","13.02%","Keeper's Assistant",8287
+"Catacombs","-","Ancient","-","12.01%","Keeper",8287
+"Catacombs","-","Ancient","-","7.16%","Terror Knight",8287
+"Catacombs","-","Ancient","-","4.77%","Vampire",8287
+"Catacombs","-","Ancient","-","4.45%","Golem",8287
+"Catacombs","-","Moon","-","46.51%","Lycan",787
+"Catacombs","-","Moon","-","18.55%","Scavenger",787
+"Catacombs","-","Moon","-","10.80%","Ghost",787
+"Catacombs","-","Moon","-","6.61%","Mummy",787
+"Catacombs","-","Moon","-","6.35%","Bat",787
+"Catacombs","-","Moon","-","5.72%","Zombie",787
+"Catacombs","-","Moon","-","5.08%","Vampire",787
+"Catacombs","-","Moon","-","0.38%","Gluttonous Zombie",787
+"Catacombs","-","Undead Emmental","-","16.83%","Mummy",1984
+"Catacombs","-","Undead Emmental","-","14.42%","Ghost",1984
+"Catacombs","-","Undead Emmental","-","13.76%","Grave Robber",1984
+"Catacombs","-","Undead Emmental","-","11.44%","Vampire",1984
+"Catacombs","-","Undead Emmental","-","10.94%","Zombot Unipire",1984
+"Catacombs","-","Undead Emmental","-","10.18%","Skeleton",1984
+"Catacombs","-","Undead Emmental","-","8.67%","Terror Knight",1984
+"Catacombs","-","Undead Emmental","-","7.66%","Ravenous Zombie",1984
+"Catacombs","-","Undead Emmental","-","3.58%","Zombie",1984
+"Catacombs","-","Undead Emmental","-","2.52%","Gluttonous Zombie",1984
+"Catacombs","-","Radioactive Blue","Antiskele","16.51%","Ghost",1417
+"Catacombs","-","Radioactive Blue","Antiskele","10.87%","Ooze",1417
+"Catacombs","-","Radioactive Blue","Antiskele","10.73%","Keeper's Assistant",1417
+"Catacombs","-","Radioactive Blue","Antiskele","10.02%","Spider",1417
+"Catacombs","-","Radioactive Blue","Antiskele","9.88%","Scavenger",1417
+"Catacombs","-","Radioactive Blue","Antiskele","9.17%","Giant Snail",1417
+"Catacombs","-","Radioactive Blue","Antiskele","6.92%","Mummy",1417
+"Catacombs","-","Radioactive Blue","Antiskele","5.01%","Vampire",1417
+"Catacombs","-","Radioactive Blue","Antiskele","4.66%","Terror Knight",1417
+"Catacombs","-","Radioactive Blue","Antiskele","4.38%","Zombie",1417
+"Catacombs","-","Radioactive Blue","Antiskele","4.23%","Bat",1417
+"Catacombs","-","Radioactive Blue","Antiskele","3.25%","Golem",1417
+"Catacombs","-","Radioactive Blue","Antiskele","2.54%","Keeper",1417
+"Catacombs","-","Radioactive Blue","Antiskele","0.92%","Lycan",1417
+"Catacombs","-","Radioactive Blue","Antiskele","0.49%","Monster",1417
+"Catacombs","-","Radioactive Blue","Antiskele","0.28%","Gluttonous Zombie",1417
+"Catacombs","-","Radioactive Blue","Antiskele","0.14%","Black Widow",1417
+"Catacombs","-","Ancient","Antiskele","18.59%","Spider",4003
+"Catacombs","-","Ancient","Antiskele","17.91%","Ooze",4003
+"Catacombs","-","Ancient","Antiskele","16.21%","Keeper's Assistant",4003
+"Catacombs","-","Ancient","Antiskele","14.41%","Scavenger",4003
+"Catacombs","-","Ancient","Antiskele","13.86%","Keeper",4003
+"Catacombs","-","Ancient","Antiskele","8.59%","Terror Knight",4003
+"Catacombs","-","Ancient","Antiskele","5.35%","Golem",4003
+"Catacombs","-","Ancient","Antiskele","5.07%","Vampire",4003
+"Catacombs","-","Undead Emmental","Antiskele","20.52%","Mummy",1891
+"Catacombs","-","Undead Emmental","Antiskele","16.76%","Ghost",1891
+"Catacombs","-","Undead Emmental","Antiskele","15.34%","Grave Robber",1891
+"Catacombs","-","Undead Emmental","Antiskele","11.63%","Zombot Unipire",1891
+"Catacombs","-","Undead Emmental","Antiskele","10.79%","Vampire",1891
+"Catacombs","-","Undead Emmental","Antiskele","10.74%","Terror Knight",1891
+"Catacombs","-","Undead Emmental","Antiskele","7.46%","Ravenous Zombie",1891
+"Catacombs","-","Undead Emmental","Antiskele","4.76%","Zombie",1891
+"Catacombs","-","Undead Emmental","Antiskele","2.01%","Gluttonous Zombie",1891

--- a/data/pop-csv/fiery-warpath.csv
+++ b/data/pop-csv/fiery-warpath.csv
@@ -1,5 +1,5 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Fiery Warpath","Portal","Gouda","-","68.17%","Theurgy Warden",663
-"Fiery Warpath","Portal","Gouda","-","31.83%","Artillery Commander",663
-"Fiery Warpath","Portal","SB+","-","63.14%","Theurgy Warden",1256
-"Fiery Warpath","Portal","SB+","-","36.86%","Artillery Commander",1256
+"Fiery Warpath","Portal","Gouda","-","67.36%","Theurgy Warden",913
+"Fiery Warpath","Portal","Gouda","-","32.64%","Artillery Commander",913
+"Fiery Warpath","Portal","SB+","-","62.93%","Theurgy Warden",1694
+"Fiery Warpath","Portal","SB+","-","37.07%","Artillery Commander",1694

--- a/data/pop-csv/forbidden-grove.csv
+++ b/data/pop-csv/forbidden-grove.csv
@@ -1,38 +1,38 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Forbidden Grove","Open","Ancient","-","17.96%","Gargoyle",12502
-"Forbidden Grove","Open","Ancient","-","15.29%","Spider",12502
-"Forbidden Grove","Open","Ancient","-","12.75%","Ghost",12502
-"Forbidden Grove","Open","Ancient","-","10.60%","Scavenger",12502
-"Forbidden Grove","Open","Ancient","-","8.01%","Vampire",12502
-"Forbidden Grove","Open","Ancient","-","6.79%","Zombie",12502
-"Forbidden Grove","Open","Ancient","-","6.25%","Bat",12502
-"Forbidden Grove","Open","Ancient","-","5.32%","Spectre",12502
-"Forbidden Grove","Open","Ancient","-","4.82%","Golem",12502
-"Forbidden Grove","Open","Ancient","-","2.90%","Gorgon",12502
-"Forbidden Grove","Open","Ancient","-","2.66%","Gate Guardian",12502
-"Forbidden Grove","Open","Ancient","-","2.63%","Reaper",12502
-"Forbidden Grove","Open","Ancient","-","2.59%","Ravenous Zombie",12502
-"Forbidden Grove","Open","Ancient","-","1.43%","Sorcerer",12502
-"Forbidden Grove","Open","Moon","-","49.62%","Lycan",1060
-"Forbidden Grove","Open","Moon","-","21.42%","Scavenger",1060
-"Forbidden Grove","Open","Moon","-","12.17%","Ghost",1060
-"Forbidden Grove","Open","Moon","-","11.13%","Sorcerer",1060
-"Forbidden Grove","Open","Moon","-","5.66%","Vampire",1060
-"Forbidden Grove","Open","Radioactive Blue","-","26.58%","Mutated Grey",4868
-"Forbidden Grove","Open","Radioactive Blue","-","26.52%","Mutated White",4868
-"Forbidden Grove","Open","Radioactive Blue","-","18.24%","Ghost",4868
-"Forbidden Grove","Open","Radioactive Blue","-","12.94%","Mutated Brown",4868
-"Forbidden Grove","Open","Radioactive Blue","-","9.39%","Zombie",4868
-"Forbidden Grove","Open","Radioactive Blue","-","4.56%","Ravenous Zombie",4868
-"Forbidden Grove","Open","Radioactive Blue","-","1.73%","Lycan",4868
-"Forbidden Grove","Open","Radioactive Blue","-","0.04%","Black Widow",4868
-"Forbidden Grove","Open","Rancid Radioactive Blue","-","26.91%","Mutated Grey",550
-"Forbidden Grove","Open","Rancid Radioactive Blue","-","22.91%","Mutated White",550
-"Forbidden Grove","Open","Rancid Radioactive Blue","-","17.82%","Ghost",550
-"Forbidden Grove","Open","Rancid Radioactive Blue","-","13.09%","Mutated Brown",550
-"Forbidden Grove","Open","Rancid Radioactive Blue","-","10.73%","Zombie",550
-"Forbidden Grove","Open","Rancid Radioactive Blue","-","6.00%","Ravenous Zombie",550
-"Forbidden Grove","Open","Rancid Radioactive Blue","-","2.18%","Lycan",550
-"Forbidden Grove","Open","Rancid Radioactive Blue","-","0.36%","Black Widow",550
-"Forbidden Grove","Closed","Ancient","-","100.00%","Realm Ripper",1668
-"Forbidden Grove","Closed","Radioactive Blue","-","100.00%","Realm Ripper",399
+"Forbidden Grove","Open","Ancient","-","18.07%","Gargoyle",13917
+"Forbidden Grove","Open","Ancient","-","15.29%","Spider",13917
+"Forbidden Grove","Open","Ancient","-","12.75%","Ghost",13917
+"Forbidden Grove","Open","Ancient","-","10.66%","Scavenger",13917
+"Forbidden Grove","Open","Ancient","-","7.85%","Vampire",13917
+"Forbidden Grove","Open","Ancient","-","6.73%","Zombie",13917
+"Forbidden Grove","Open","Ancient","-","6.27%","Bat",13917
+"Forbidden Grove","Open","Ancient","-","5.39%","Spectre",13917
+"Forbidden Grove","Open","Ancient","-","4.94%","Golem",13917
+"Forbidden Grove","Open","Ancient","-","2.82%","Gorgon",13917
+"Forbidden Grove","Open","Ancient","-","2.64%","Reaper",13917
+"Forbidden Grove","Open","Ancient","-","2.62%","Gate Guardian",13917
+"Forbidden Grove","Open","Ancient","-","2.57%","Ravenous Zombie",13917
+"Forbidden Grove","Open","Ancient","-","1.41%","Sorcerer",13917
+"Forbidden Grove","Open","Moon","-","49.07%","Lycan",1239
+"Forbidden Grove","Open","Moon","-","21.15%","Scavenger",1239
+"Forbidden Grove","Open","Moon","-","12.75%","Ghost",1239
+"Forbidden Grove","Open","Moon","-","11.22%","Sorcerer",1239
+"Forbidden Grove","Open","Moon","-","5.81%","Vampire",1239
+"Forbidden Grove","Open","Radioactive Blue","-","26.72%","Mutated White",5218
+"Forbidden Grove","Open","Radioactive Blue","-","26.43%","Mutated Grey",5218
+"Forbidden Grove","Open","Radioactive Blue","-","18.26%","Ghost",5218
+"Forbidden Grove","Open","Radioactive Blue","-","12.76%","Mutated Brown",5218
+"Forbidden Grove","Open","Radioactive Blue","-","9.47%","Zombie",5218
+"Forbidden Grove","Open","Radioactive Blue","-","4.60%","Ravenous Zombie",5218
+"Forbidden Grove","Open","Radioactive Blue","-","1.71%","Lycan",5218
+"Forbidden Grove","Open","Radioactive Blue","-","0.06%","Black Widow",5218
+"Forbidden Grove","Open","Rancid Radioactive Blue","-","26.32%","Mutated Grey",585
+"Forbidden Grove","Open","Rancid Radioactive Blue","-","23.59%","Mutated White",585
+"Forbidden Grove","Open","Rancid Radioactive Blue","-","18.12%","Ghost",585
+"Forbidden Grove","Open","Rancid Radioactive Blue","-","13.50%","Mutated Brown",585
+"Forbidden Grove","Open","Rancid Radioactive Blue","-","10.26%","Zombie",585
+"Forbidden Grove","Open","Rancid Radioactive Blue","-","5.81%","Ravenous Zombie",585
+"Forbidden Grove","Open","Rancid Radioactive Blue","-","2.05%","Lycan",585
+"Forbidden Grove","Open","Rancid Radioactive Blue","-","0.34%","Black Widow",585
+"Forbidden Grove","Closed","Ancient","-","100.00%","Realm Ripper",1793
+"Forbidden Grove","Closed","Radioactive Blue","-","100.00%","Realm Ripper",430

--- a/data/pop-csv/fort-rox.csv
+++ b/data/pop-csv/fort-rox.csv
@@ -1,187 +1,200 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Fort Rox","Day","Gouda","-","29.82%","Meteorite Miner",43063
-"Fort Rox","Day","Gouda","-","29.69%","Mischievous Meteorite Miner",43063
-"Fort Rox","Day","Gouda","-","17.66%","Hardworking Hauler",43063
-"Fort Rox","Day","Gouda","-","11.95%","Meteorite Snacker",43063
-"Fort Rox","Day","Gouda","-","5.89%","Meteorite Mover",43063
-"Fort Rox","Day","Gouda","-","4.99%","Mining Materials Manager",43063
-"Fort Rox","Day","Brie","-","30.32%","Mischievous Meteorite Miner",5726
-"Fort Rox","Day","Brie","-","28.82%","Meteorite Miner",5726
-"Fort Rox","Day","Brie","-","18.37%","Hardworking Hauler",5726
-"Fort Rox","Day","Brie","-","12.02%","Meteorite Snacker",5726
-"Fort Rox","Day","Brie","-","5.43%","Meteorite Mover",5726
-"Fort Rox","Day","Brie","-","5.05%","Mining Materials Manager",5726
-"Fort Rox","Day","SB+","-","24.23%","Mischievous Meteorite Miner",2629
-"Fort Rox","Day","SB+","-","23.85%","Meteorite Miner",2629
-"Fort Rox","Day","SB+","-","17.84%","Hardworking Hauler",2629
-"Fort Rox","Day","SB+","-","16.09%","Mining Materials Manager",2629
-"Fort Rox","Day","SB+","-","15.37%","Meteorite Snacker",2629
-"Fort Rox","Day","SB+","-","2.62%","Meteorite Mover",2629
-"Fort Rox","Day","Crescent","-","25.03%","Meteorite Miner",927
-"Fort Rox","Day","Crescent","-","23.84%","Mischievous Meteorite Miner",927
-"Fort Rox","Day","Crescent","-","19.20%","Meteorite Snacker",927
-"Fort Rox","Day","Crescent","-","14.99%","Hardworking Hauler",927
-"Fort Rox","Day","Crescent","-","10.90%","Meteorite Mover",927
-"Fort Rox","Day","Crescent","-","6.04%","Mining Materials Manager",927
-"Fort Rox","Day","Moon","-","28.82%","Meteorite Snacker",465
-"Fort Rox","Day","Moon","-","24.52%","Meteorite Miner",465
-"Fort Rox","Day","Moon","-","24.52%","Mischievous Meteorite Miner",465
-"Fort Rox","Day","Moon","-","10.75%","Meteorite Mover",465
-"Fort Rox","Day","Moon","-","7.53%","Hardworking Hauler",465
-"Fort Rox","Day","Moon","-","3.87%","Mining Materials Manager",465
-"Fort Rox","Twilight","Gouda","-","27.53%","Battering Ram",661
-"Fort Rox","Twilight","Gouda","-","15.89%","Mischievous Wereminer",661
-"Fort Rox","Twilight","Gouda","-","15.73%","Werehauler",661
-"Fort Rox","Twilight","Gouda","-","12.56%","Reveling Lycanthrope",661
-"Fort Rox","Twilight","Gouda","-","12.56%","Nightmancer",661
-"Fort Rox","Twilight","Gouda","-","9.68%","Wereminer",661
-"Fort Rox","Twilight","Gouda","-","6.05%","Alpha Weremouse",661
-"Fort Rox","Twilight","SB+","-","21.23%","Battering Ram",146
-"Fort Rox","Twilight","SB+","-","18.49%","Werehauler",146
-"Fort Rox","Twilight","SB+","-","13.01%","Nightmancer",146
-"Fort Rox","Twilight","SB+","-","12.33%","Mischievous Wereminer",146
-"Fort Rox","Twilight","SB+","-","11.64%","Alpha Weremouse",146
-"Fort Rox","Twilight","SB+","-","10.27%","Reveling Lycanthrope",146
-"Fort Rox","Twilight","SB+","-","9.59%","Wereminer",146
-"Fort Rox","Twilight","SB+","-","3.42%","Night Shift Materials Manager",146
-"Fort Rox","Twilight","Crescent","-","23.00%","Werehauler",24321
-"Fort Rox","Twilight","Crescent","-","19.06%","Alpha Weremouse",24321
-"Fort Rox","Twilight","Crescent","-","15.46%","Reveling Lycanthrope",24321
-"Fort Rox","Twilight","Crescent","-","14.60%","Mischievous Wereminer",24321
-"Fort Rox","Twilight","Crescent","-","14.50%","Wereminer",24321
-"Fort Rox","Twilight","Crescent","-","7.90%","Night Shift Materials Manager",24321
-"Fort Rox","Twilight","Crescent","-","5.48%","Nightmancer",24321
-"Fort Rox","Twilight","Moon","-","20.59%","Mischievous Wereminer",6795
-"Fort Rox","Twilight","Moon","-","18.23%","Alpha Weremouse",6795
-"Fort Rox","Twilight","Moon","-","16.26%","Werehauler",6795
-"Fort Rox","Twilight","Moon","-","16.00%","Wereminer",6795
-"Fort Rox","Twilight","Moon","-","13.54%","Reveling Lycanthrope",6795
-"Fort Rox","Twilight","Moon","-","10.15%","Night Shift Materials Manager",6795
-"Fort Rox","Twilight","Moon","-","5.22%","Nightmancer",6795
-"Fort Rox","Midnight","Gouda","-","26.11%","Battering Ram",180
-"Fort Rox","Midnight","Gouda","-","20.56%","Werehauler",180
-"Fort Rox","Midnight","Gouda","-","16.11%","Nightmancer",180
-"Fort Rox","Midnight","Gouda","-","8.89%","Alpha Weremouse",180
-"Fort Rox","Midnight","Gouda","-","6.11%","Night Watcher",180
-"Fort Rox","Midnight","Gouda","-","5.56%","Mischievous Wereminer",180
-"Fort Rox","Midnight","Gouda","-","5.56%","Hypnotized Gunslinger",180
-"Fort Rox","Midnight","Gouda","-","3.89%","Wereminer",180
-"Fort Rox","Midnight","Gouda","-","2.78%","Meteorite Golem",180
-"Fort Rox","Midnight","Gouda","-","2.22%","Arcane Summoner",180
-"Fort Rox","Midnight","Gouda","-","1.11%","Wealthy Werewarrior",180
-"Fort Rox","Midnight","Gouda","-","1.11%","Reveling Lycanthrope",180
-"Fort Rox","Midnight","Crescent","-","14.04%","Alpha Weremouse",14779
-"Fort Rox","Midnight","Crescent","-","13.32%","Werehauler",14779
-"Fort Rox","Midnight","Crescent","-","11.56%","Nightmancer",14779
-"Fort Rox","Midnight","Crescent","-","10.18%","Mischievous Wereminer",14779
-"Fort Rox","Midnight","Crescent","-","9.74%","Wealthy Werewarrior",14779
-"Fort Rox","Midnight","Crescent","-","9.06%","Wereminer",14779
-"Fort Rox","Midnight","Crescent","-","7.93%","Night Shift Materials Manager",14779
-"Fort Rox","Midnight","Crescent","-","5.59%","Hypnotized Gunslinger",14779
-"Fort Rox","Midnight","Crescent","-","5.56%","Reveling Lycanthrope",14779
-"Fort Rox","Midnight","Crescent","-","4.68%","Night Watcher",14779
-"Fort Rox","Midnight","Crescent","-","4.57%","Arcane Summoner",14779
-"Fort Rox","Midnight","Crescent","-","3.78%","Meteorite Golem",14779
-"Fort Rox","Midnight","Moon","-","18.75%","Alpha Weremouse",4288
-"Fort Rox","Midnight","Moon","-","11.43%","Mischievous Wereminer",4288
-"Fort Rox","Midnight","Moon","-","10.17%","Nightmancer",4288
-"Fort Rox","Midnight","Moon","-","10.17%","Night Shift Materials Manager",4288
-"Fort Rox","Midnight","Moon","-","9.54%","Wereminer",4288
-"Fort Rox","Midnight","Moon","-","9.19%","Wealthy Werewarrior",4288
-"Fort Rox","Midnight","Moon","-","6.53%","Werehauler",4288
-"Fort Rox","Midnight","Moon","-","6.11%","Reveling Lycanthrope",4288
-"Fort Rox","Midnight","Moon","-","5.13%","Hypnotized Gunslinger",4288
-"Fort Rox","Midnight","Moon","-","4.50%","Meteorite Golem",4288
-"Fort Rox","Midnight","Moon","-","4.43%","Night Watcher",4288
-"Fort Rox","Midnight","Moon","-","4.06%","Arcane Summoner",4288
-"Fort Rox","Pitch","Crescent","-","13.05%","Hypnotized Gunslinger",4826
-"Fort Rox","Pitch","Crescent","-","10.15%","Wealthy Werewarrior",4826
-"Fort Rox","Pitch","Crescent","-","10.15%","Nightmancer",4826
-"Fort Rox","Pitch","Crescent","-","8.64%","Nightfire",4826
-"Fort Rox","Pitch","Crescent","-","7.75%","Night Shift Materials Manager",4826
-"Fort Rox","Pitch","Crescent","-","7.23%","Alpha Weremouse",4826
-"Fort Rox","Pitch","Crescent","-","6.28%","Werehauler",4826
-"Fort Rox","Pitch","Crescent","-","5.97%","Meteorite Golem",4826
-"Fort Rox","Pitch","Crescent","-","5.57%","Arcane Summoner",4826
-"Fort Rox","Pitch","Crescent","-","5.08%","Wereminer",4826
-"Fort Rox","Pitch","Crescent","-","4.66%","Night Watcher",4826
-"Fort Rox","Pitch","Crescent","-","4.39%","Reveling Lycanthrope",4826
-"Fort Rox","Pitch","Crescent","-","4.31%","Cursed Taskmaster",4826
-"Fort Rox","Pitch","Crescent","-","3.63%","Mischievous Wereminer",4826
-"Fort Rox","Pitch","Crescent","-","3.13%","Meteorite Mystic",4826
-"Fort Rox","Pitch","Moon","-","15.41%","Hypnotized Gunslinger",1823
-"Fort Rox","Pitch","Moon","-","10.53%","Night Shift Materials Manager",1823
-"Fort Rox","Pitch","Moon","-","9.60%","Wealthy Werewarrior",1823
-"Fort Rox","Pitch","Moon","-","8.12%","Nightmancer",1823
-"Fort Rox","Pitch","Moon","-","7.46%","Alpha Weremouse",1823
-"Fort Rox","Pitch","Moon","-","6.53%","Meteorite Golem",1823
-"Fort Rox","Pitch","Moon","-","6.20%","Wereminer",1823
-"Fort Rox","Pitch","Moon","-","5.87%","Night Watcher",1823
-"Fort Rox","Pitch","Moon","-","5.43%","Cursed Taskmaster",1823
-"Fort Rox","Pitch","Moon","-","4.94%","Nightfire",1823
-"Fort Rox","Pitch","Moon","-","4.94%","Arcane Summoner",1823
-"Fort Rox","Pitch","Moon","-","4.22%","Mischievous Wereminer",1823
-"Fort Rox","Pitch","Moon","-","3.89%","Meteorite Mystic",1823
-"Fort Rox","Pitch","Moon","-","3.51%","Werehauler",1823
-"Fort Rox","Pitch","Moon","-","3.35%","Reveling Lycanthrope",1823
-"Fort Rox","Utter Darkness","Crescent","-","15.39%","Hypnotized Gunslinger",9329
-"Fort Rox","Utter Darkness","Crescent","-","11.98%","Meteorite Golem",9329
-"Fort Rox","Utter Darkness","Crescent","-","11.80%","Cursed Taskmaster",9329
-"Fort Rox","Utter Darkness","Crescent","-","11.54%","Nightfire",9329
-"Fort Rox","Utter Darkness","Crescent","-","9.60%","Night Watcher",9329
-"Fort Rox","Utter Darkness","Crescent","-","7.73%","Meteorite Mystic",9329
-"Fort Rox","Utter Darkness","Crescent","-","6.82%","Alpha Weremouse",9329
-"Fort Rox","Utter Darkness","Crescent","-","5.51%","Arcane Summoner",9329
-"Fort Rox","Utter Darkness","Crescent","-","5.12%","Wealthy Werewarrior",9329
-"Fort Rox","Utter Darkness","Crescent","-","5.11%","Nightmancer",9329
-"Fort Rox","Utter Darkness","Crescent","-","2.94%","Wereminer",9329
-"Fort Rox","Utter Darkness","Crescent","-","2.87%","Werehauler",9329
-"Fort Rox","Utter Darkness","Crescent","-","1.97%","Mischievous Wereminer",9329
-"Fort Rox","Utter Darkness","Crescent","-","1.18%","Reveling Lycanthrope",9329
-"Fort Rox","Utter Darkness","Crescent","-","0.42%","Night Shift Materials Manager",9329
-"Fort Rox","Utter Darkness","Moon","-","14.38%","Night Watcher",3923
-"Fort Rox","Utter Darkness","Moon","-","11.96%","Cursed Taskmaster",3923
-"Fort Rox","Utter Darkness","Moon","-","11.85%","Meteorite Golem",3923
-"Fort Rox","Utter Darkness","Moon","-","11.52%","Hypnotized Gunslinger",3923
-"Fort Rox","Utter Darkness","Moon","-","8.97%","Meteorite Mystic",3923
-"Fort Rox","Utter Darkness","Moon","-","8.64%","Nightfire",3923
-"Fort Rox","Utter Darkness","Moon","-","6.65%","Alpha Weremouse",3923
-"Fort Rox","Utter Darkness","Moon","-","5.00%","Arcane Summoner",3923
-"Fort Rox","Utter Darkness","Moon","-","4.92%","Wealthy Werewarrior",3923
-"Fort Rox","Utter Darkness","Moon","-","4.89%","Nightmancer",3923
-"Fort Rox","Utter Darkness","Moon","-","4.64%","Wereminer",3923
-"Fort Rox","Utter Darkness","Moon","-","2.70%","Mischievous Wereminer",3923
-"Fort Rox","Utter Darkness","Moon","-","1.61%","Reveling Lycanthrope",3923
-"Fort Rox","Utter Darkness","Moon","-","1.27%","Night Shift Materials Manager",3923
-"Fort Rox","Utter Darkness","Moon","-","0.99%","Werehauler",3923
-"Fort Rox","First Light","Gouda","-","64.60%","Battering Ram",113
-"Fort Rox","First Light","Gouda","-","23.01%","Nightfire",113
-"Fort Rox","First Light","Gouda","-","3.54%","Night Watcher",113
-"Fort Rox","First Light","Gouda","-","3.54%","Cursed Taskmaster",113
-"Fort Rox","First Light","Gouda","-","2.65%","Meteorite Golem",113
-"Fort Rox","First Light","Gouda","-","2.65%","Meteorite Mystic",113
-"Fort Rox","First Light","Crescent","-","24.14%","Nightfire",9743
-"Fort Rox","First Light","Crescent","-","15.42%","Cursed Taskmaster",9743
-"Fort Rox","First Light","Crescent","-","15.10%","Meteorite Golem",9743
-"Fort Rox","First Light","Crescent","-","14.32%","Night Watcher",9743
-"Fort Rox","First Light","Crescent","-","12.03%","Hypnotized Gunslinger",9743
-"Fort Rox","First Light","Crescent","-","9.72%","Meteorite Mystic",9743
-"Fort Rox","First Light","Crescent","-","9.28%","Arcane Summoner",9743
-"Fort Rox","First Light","Moon","-","23.58%","Cursed Taskmaster",5105
-"Fort Rox","First Light","Moon","-","22.37%","Nightfire",5105
-"Fort Rox","First Light","Moon","-","13.24%","Night Watcher",5105
-"Fort Rox","First Light","Moon","-","11.69%","Arcane Summoner",5105
-"Fort Rox","First Light","Moon","-","10.01%","Meteorite Golem",5105
-"Fort Rox","First Light","Moon","-","9.62%","Hypnotized Gunslinger",5105
-"Fort Rox","First Light","Moon","-","9.48%","Meteorite Mystic",5105
-"Fort Rox","Dawn","Gouda","-","39.48%","Monster of the Meteor",499
-"Fort Rox","Dawn","Gouda","-","31.06%","Battering Ram",499
-"Fort Rox","Dawn","Gouda","-","29.46%","Dawn Guardian",499
-"Fort Rox","Dawn","SB+","-","45.25%","Dawn Guardian",316
-"Fort Rox","Dawn","SB+","-","36.08%","Monster of the Meteor",316
-"Fort Rox","Dawn","SB+","-","18.67%","Battering Ram",316
-"Fort Rox","Dawn","Crescent","-","51.28%","Dawn Guardian",8115
-"Fort Rox","Dawn","Crescent","-","48.72%","Monster of the Meteor",8115
-"Fort Rox","Dawn","Moon","-","50.48%","Dawn Guardian",8454
-"Fort Rox","Dawn","Moon","-","49.52%","Monster of the Meteor",8454
+"Fort Rox","Day","Gouda","-","29.84%","Meteorite Miner",59000
+"Fort Rox","Day","Gouda","-","29.77%","Mischievous Meteorite Miner",59000
+"Fort Rox","Day","Gouda","-","17.53%","Hardworking Hauler",59000
+"Fort Rox","Day","Gouda","-","11.94%","Meteorite Snacker",59000
+"Fort Rox","Day","Gouda","-","5.94%","Meteorite Mover",59000
+"Fort Rox","Day","Gouda","-","5.00%","Mining Materials Manager",59000
+"Fort Rox","Day","Brie","-","30.13%","Mischievous Meteorite Miner",6692
+"Fort Rox","Day","Brie","-","28.71%","Meteorite Miner",6692
+"Fort Rox","Day","Brie","-","18.37%","Hardworking Hauler",6692
+"Fort Rox","Day","Brie","-","12.00%","Meteorite Snacker",6692
+"Fort Rox","Day","Brie","-","5.69%","Meteorite Mover",6692
+"Fort Rox","Day","Brie","-","5.11%","Mining Materials Manager",6692
+"Fort Rox","Day","SB+","-","24.05%","Mischievous Meteorite Miner",3380
+"Fort Rox","Day","SB+","-","23.37%","Meteorite Miner",3380
+"Fort Rox","Day","SB+","-","17.37%","Hardworking Hauler",3380
+"Fort Rox","Day","SB+","-","17.07%","Mining Materials Manager",3380
+"Fort Rox","Day","SB+","-","15.65%","Meteorite Snacker",3380
+"Fort Rox","Day","SB+","-","2.49%","Meteorite Mover",3380
+"Fort Rox","Day","Crescent","-","24.43%","Meteorite Miner",1367
+"Fort Rox","Day","Crescent","-","24.36%","Mischievous Meteorite Miner",1367
+"Fort Rox","Day","Crescent","-","19.60%","Meteorite Snacker",1367
+"Fort Rox","Day","Crescent","-","16.24%","Hardworking Hauler",1367
+"Fort Rox","Day","Crescent","-","10.31%","Meteorite Mover",1367
+"Fort Rox","Day","Crescent","-","5.05%","Mining Materials Manager",1367
+"Fort Rox","Day","Moon","-","29.79%","Meteorite Snacker",678
+"Fort Rox","Day","Moon","-","23.45%","Meteorite Miner",678
+"Fort Rox","Day","Moon","-","23.16%","Mischievous Meteorite Miner",678
+"Fort Rox","Day","Moon","-","11.36%","Meteorite Mover",678
+"Fort Rox","Day","Moon","-","7.67%","Hardworking Hauler",678
+"Fort Rox","Day","Moon","-","4.57%","Mining Materials Manager",678
+"Fort Rox","Twilight","Gouda","-","27.83%","Battering Ram",1053
+"Fort Rox","Twilight","Gouda","-","16.52%","Werehauler",1053
+"Fort Rox","Twilight","Gouda","-","15.38%","Mischievous Wereminer",1053
+"Fort Rox","Twilight","Gouda","-","13.39%","Nightmancer",1053
+"Fort Rox","Twilight","Gouda","-","12.25%","Reveling Lycanthrope",1053
+"Fort Rox","Twilight","Gouda","-","8.74%","Wereminer",1053
+"Fort Rox","Twilight","Gouda","-","5.89%","Alpha Weremouse",1053
+"Fort Rox","Twilight","SB+","-","20.74%","Battering Ram",217
+"Fort Rox","Twilight","SB+","-","16.59%","Werehauler",217
+"Fort Rox","Twilight","SB+","-","14.29%","Mischievous Wereminer",217
+"Fort Rox","Twilight","SB+","-","12.44%","Alpha Weremouse",217
+"Fort Rox","Twilight","SB+","-","12.44%","Nightmancer",217
+"Fort Rox","Twilight","SB+","-","11.52%","Reveling Lycanthrope",217
+"Fort Rox","Twilight","SB+","-","9.22%","Wereminer",217
+"Fort Rox","Twilight","SB+","-","2.76%","Night Shift Materials Manager",217
+"Fort Rox","Twilight","Crescent","-","23.00%","Werehauler",32680
+"Fort Rox","Twilight","Crescent","-","18.97%","Alpha Weremouse",32680
+"Fort Rox","Twilight","Crescent","-","15.62%","Reveling Lycanthrope",32680
+"Fort Rox","Twilight","Crescent","-","14.62%","Wereminer",32680
+"Fort Rox","Twilight","Crescent","-","14.60%","Mischievous Wereminer",32680
+"Fort Rox","Twilight","Crescent","-","7.86%","Night Shift Materials Manager",32680
+"Fort Rox","Twilight","Crescent","-","5.32%","Nightmancer",32680
+"Fort Rox","Twilight","Moon","-","20.49%","Mischievous Wereminer",9495
+"Fort Rox","Twilight","Moon","-","18.41%","Alpha Weremouse",9495
+"Fort Rox","Twilight","Moon","-","16.33%","Wereminer",9495
+"Fort Rox","Twilight","Moon","-","16.13%","Werehauler",9495
+"Fort Rox","Twilight","Moon","-","13.66%","Reveling Lycanthrope",9495
+"Fort Rox","Twilight","Moon","-","9.92%","Night Shift Materials Manager",9495
+"Fort Rox","Twilight","Moon","-","5.04%","Nightmancer",9495
+"Fort Rox","Midnight","Gouda","-","27.07%","Battering Ram",229
+"Fort Rox","Midnight","Gouda","-","17.90%","Werehauler",229
+"Fort Rox","Midnight","Gouda","-","15.28%","Nightmancer",229
+"Fort Rox","Midnight","Gouda","-","10.04%","Alpha Weremouse",229
+"Fort Rox","Midnight","Gouda","-","6.55%","Hypnotized Gunslinger",229
+"Fort Rox","Midnight","Gouda","-","6.11%","Mischievous Wereminer",229
+"Fort Rox","Midnight","Gouda","-","5.68%","Night Watcher",229
+"Fort Rox","Midnight","Gouda","-","3.93%","Wereminer",229
+"Fort Rox","Midnight","Gouda","-","2.62%","Meteorite Golem",229
+"Fort Rox","Midnight","Gouda","-","2.18%","Arcane Summoner",229
+"Fort Rox","Midnight","Gouda","-","1.31%","Wealthy Werewarrior",229
+"Fort Rox","Midnight","Gouda","-","1.31%","Reveling Lycanthrope",229
+"Fort Rox","Midnight","Crescent","-","14.00%","Alpha Weremouse",19895
+"Fort Rox","Midnight","Crescent","-","13.24%","Werehauler",19895
+"Fort Rox","Midnight","Crescent","-","11.49%","Nightmancer",19895
+"Fort Rox","Midnight","Crescent","-","10.24%","Mischievous Wereminer",19895
+"Fort Rox","Midnight","Crescent","-","9.69%","Wealthy Werewarrior",19895
+"Fort Rox","Midnight","Crescent","-","9.04%","Wereminer",19895
+"Fort Rox","Midnight","Crescent","-","7.86%","Night Shift Materials Manager",19895
+"Fort Rox","Midnight","Crescent","-","5.63%","Hypnotized Gunslinger",19895
+"Fort Rox","Midnight","Crescent","-","5.59%","Reveling Lycanthrope",19895
+"Fort Rox","Midnight","Crescent","-","4.69%","Night Watcher",19895
+"Fort Rox","Midnight","Crescent","-","4.61%","Arcane Summoner",19895
+"Fort Rox","Midnight","Crescent","-","3.93%","Meteorite Golem",19895
+"Fort Rox","Midnight","Moon","-","18.39%","Alpha Weremouse",6067
+"Fort Rox","Midnight","Moon","-","11.39%","Mischievous Wereminer",6067
+"Fort Rox","Midnight","Moon","-","10.17%","Nightmancer",6067
+"Fort Rox","Midnight","Moon","-","10.04%","Wereminer",6067
+"Fort Rox","Midnight","Moon","-","10.04%","Night Shift Materials Manager",6067
+"Fort Rox","Midnight","Moon","-","9.18%","Wealthy Werewarrior",6067
+"Fort Rox","Midnight","Moon","-","6.56%","Werehauler",6067
+"Fort Rox","Midnight","Moon","-","5.74%","Reveling Lycanthrope",6067
+"Fort Rox","Midnight","Moon","-","5.14%","Hypnotized Gunslinger",6067
+"Fort Rox","Midnight","Moon","-","4.52%","Meteorite Golem",6067
+"Fort Rox","Midnight","Moon","-","4.47%","Night Watcher",6067
+"Fort Rox","Midnight","Moon","-","4.37%","Arcane Summoner",6067
+"Fort Rox","Pitch","Crescent","-","13.42%","Hypnotized Gunslinger",6481
+"Fort Rox","Pitch","Crescent","-","10.17%","Nightmancer",6481
+"Fort Rox","Pitch","Crescent","-","10.15%","Wealthy Werewarrior",6481
+"Fort Rox","Pitch","Crescent","-","8.66%","Nightfire",6481
+"Fort Rox","Pitch","Crescent","-","7.68%","Night Shift Materials Manager",6481
+"Fort Rox","Pitch","Crescent","-","7.01%","Alpha Weremouse",6481
+"Fort Rox","Pitch","Crescent","-","6.05%","Werehauler",6481
+"Fort Rox","Pitch","Crescent","-","5.85%","Meteorite Golem",6481
+"Fort Rox","Pitch","Crescent","-","5.28%","Arcane Summoner",6481
+"Fort Rox","Pitch","Crescent","-","5.22%","Wereminer",6481
+"Fort Rox","Pitch","Crescent","-","4.91%","Night Watcher",6481
+"Fort Rox","Pitch","Crescent","-","4.40%","Cursed Taskmaster",6481
+"Fort Rox","Pitch","Crescent","-","4.21%","Reveling Lycanthrope",6481
+"Fort Rox","Pitch","Crescent","-","3.73%","Mischievous Wereminer",6481
+"Fort Rox","Pitch","Crescent","-","3.27%","Meteorite Mystic",6481
+"Fort Rox","Pitch","Moon","-","15.52%","Hypnotized Gunslinger",2494
+"Fort Rox","Pitch","Moon","-","10.38%","Night Shift Materials Manager",2494
+"Fort Rox","Pitch","Moon","-","9.94%","Wealthy Werewarrior",2494
+"Fort Rox","Pitch","Moon","-","8.58%","Nightmancer",2494
+"Fort Rox","Pitch","Moon","-","7.10%","Alpha Weremouse",2494
+"Fort Rox","Pitch","Moon","-","6.90%","Meteorite Golem",2494
+"Fort Rox","Pitch","Moon","-","6.26%","Wereminer",2494
+"Fort Rox","Pitch","Moon","-","5.73%","Night Watcher",2494
+"Fort Rox","Pitch","Moon","-","5.17%","Cursed Taskmaster",2494
+"Fort Rox","Pitch","Moon","-","4.65%","Arcane Summoner",2494
+"Fort Rox","Pitch","Moon","-","4.57%","Nightfire",2494
+"Fort Rox","Pitch","Moon","-","4.49%","Meteorite Mystic",2494
+"Fort Rox","Pitch","Moon","-","3.93%","Mischievous Wereminer",2494
+"Fort Rox","Pitch","Moon","-","3.57%","Reveling Lycanthrope",2494
+"Fort Rox","Pitch","Moon","-","3.21%","Werehauler",2494
+"Fort Rox","Utter Darkness","Gouda","-","68.22%","Battering Ram",107
+"Fort Rox","Utter Darkness","Gouda","-","4.67%","Nightfire",107
+"Fort Rox","Utter Darkness","Gouda","-","4.67%","Nightmancer",107
+"Fort Rox","Utter Darkness","Gouda","-","3.74%","Meteorite Golem",107
+"Fort Rox","Utter Darkness","Gouda","-","2.80%","Alpha Weremouse",107
+"Fort Rox","Utter Darkness","Gouda","-","2.80%","Night Watcher",107
+"Fort Rox","Utter Darkness","Gouda","-","2.80%","Wereminer",107
+"Fort Rox","Utter Darkness","Gouda","-","2.80%","Cursed Taskmaster",107
+"Fort Rox","Utter Darkness","Gouda","-","1.87%","Meteorite Mystic",107
+"Fort Rox","Utter Darkness","Gouda","-","1.87%","Hypnotized Gunslinger",107
+"Fort Rox","Utter Darkness","Gouda","-","1.87%","Reveling Lycanthrope",107
+"Fort Rox","Utter Darkness","Gouda","-","0.93%","Arcane Summoner",107
+"Fort Rox","Utter Darkness","Gouda","-","0.93%","Wealthy Werewarrior",107
+"Fort Rox","Utter Darkness","Crescent","-","15.39%","Hypnotized Gunslinger",12636
+"Fort Rox","Utter Darkness","Crescent","-","12.09%","Meteorite Golem",12636
+"Fort Rox","Utter Darkness","Crescent","-","11.72%","Cursed Taskmaster",12636
+"Fort Rox","Utter Darkness","Crescent","-","11.63%","Nightfire",12636
+"Fort Rox","Utter Darkness","Crescent","-","9.39%","Night Watcher",12636
+"Fort Rox","Utter Darkness","Crescent","-","7.85%","Meteorite Mystic",12636
+"Fort Rox","Utter Darkness","Crescent","-","6.73%","Alpha Weremouse",12636
+"Fort Rox","Utter Darkness","Crescent","-","5.77%","Arcane Summoner",12636
+"Fort Rox","Utter Darkness","Crescent","-","5.07%","Wealthy Werewarrior",12636
+"Fort Rox","Utter Darkness","Crescent","-","5.05%","Nightmancer",12636
+"Fort Rox","Utter Darkness","Crescent","-","3.05%","Werehauler",12636
+"Fort Rox","Utter Darkness","Crescent","-","2.86%","Wereminer",12636
+"Fort Rox","Utter Darkness","Crescent","-","1.92%","Mischievous Wereminer",12636
+"Fort Rox","Utter Darkness","Crescent","-","1.08%","Reveling Lycanthrope",12636
+"Fort Rox","Utter Darkness","Crescent","-","0.39%","Night Shift Materials Manager",12636
+"Fort Rox","Utter Darkness","Moon","-","13.88%","Night Watcher",5433
+"Fort Rox","Utter Darkness","Moon","-","12.07%","Meteorite Golem",5433
+"Fort Rox","Utter Darkness","Moon","-","11.82%","Cursed Taskmaster",5433
+"Fort Rox","Utter Darkness","Moon","-","11.34%","Hypnotized Gunslinger",5433
+"Fort Rox","Utter Darkness","Moon","-","9.13%","Nightfire",5433
+"Fort Rox","Utter Darkness","Moon","-","8.60%","Meteorite Mystic",5433
+"Fort Rox","Utter Darkness","Moon","-","6.53%","Alpha Weremouse",5433
+"Fort Rox","Utter Darkness","Moon","-","5.43%","Arcane Summoner",5433
+"Fort Rox","Utter Darkness","Moon","-","5.26%","Wealthy Werewarrior",5433
+"Fort Rox","Utter Darkness","Moon","-","4.97%","Nightmancer",5433
+"Fort Rox","Utter Darkness","Moon","-","4.77%","Wereminer",5433
+"Fort Rox","Utter Darkness","Moon","-","2.61%","Mischievous Wereminer",5433
+"Fort Rox","Utter Darkness","Moon","-","1.42%","Reveling Lycanthrope",5433
+"Fort Rox","Utter Darkness","Moon","-","1.14%","Night Shift Materials Manager",5433
+"Fort Rox","Utter Darkness","Moon","-","1.03%","Werehauler",5433
+"Fort Rox","First Light","Gouda","-","62.96%","Battering Ram",135
+"Fort Rox","First Light","Gouda","-","23.70%","Nightfire",135
+"Fort Rox","First Light","Gouda","-","3.70%","Night Watcher",135
+"Fort Rox","First Light","Gouda","-","3.70%","Meteorite Golem",135
+"Fort Rox","First Light","Gouda","-","2.96%","Cursed Taskmaster",135
+"Fort Rox","First Light","Gouda","-","2.96%","Meteorite Mystic",135
+"Fort Rox","First Light","Crescent","-","23.98%","Nightfire",13457
+"Fort Rox","First Light","Crescent","-","15.44%","Cursed Taskmaster",13457
+"Fort Rox","First Light","Crescent","-","14.99%","Meteorite Golem",13457
+"Fort Rox","First Light","Crescent","-","14.33%","Night Watcher",13457
+"Fort Rox","First Light","Crescent","-","12.19%","Hypnotized Gunslinger",13457
+"Fort Rox","First Light","Crescent","-","9.76%","Meteorite Mystic",13457
+"Fort Rox","First Light","Crescent","-","9.31%","Arcane Summoner",13457
+"Fort Rox","First Light","Moon","-","23.93%","Cursed Taskmaster",7078
+"Fort Rox","First Light","Moon","-","21.98%","Nightfire",7078
+"Fort Rox","First Light","Moon","-","13.39%","Night Watcher",7078
+"Fort Rox","First Light","Moon","-","11.88%","Arcane Summoner",7078
+"Fort Rox","First Light","Moon","-","9.69%","Meteorite Mystic",7078
+"Fort Rox","First Light","Moon","-","9.61%","Hypnotized Gunslinger",7078
+"Fort Rox","First Light","Moon","-","9.51%","Meteorite Golem",7078
+"Fort Rox","Dawn","Gouda","-","38.37%","Monster of the Meteor",649
+"Fort Rox","Dawn","Gouda","-","30.97%","Battering Ram",649
+"Fort Rox","Dawn","Gouda","-","30.66%","Dawn Guardian",649
+"Fort Rox","Dawn","SB+","-","43.02%","Dawn Guardian",351
+"Fort Rox","Dawn","SB+","-","37.61%","Monster of the Meteor",351
+"Fort Rox","Dawn","SB+","-","19.37%","Battering Ram",351
+"Fort Rox","Dawn","Crescent","-","51.28%","Dawn Guardian",11329
+"Fort Rox","Dawn","Crescent","-","48.72%","Monster of the Meteor",11329
+"Fort Rox","Dawn","Moon","-","50.87%","Dawn Guardian",11697
+"Fort Rox","Dawn","Moon","-","49.13%","Monster of the Meteor",11697
 "Fort Rox","Portal","Sunrise","-","100.00%","Heart of the Meteor",

--- a/data/pop-csv/fungal-cavern.csv
+++ b/data/pop-csv/fungal-cavern.csv
@@ -1,60 +1,60 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Fungal Cavern","-","SB+","-","14.59%","Funglore",10719
-"Fungal Cavern","-","SB+","-","14.12%","Lumahead",10719
-"Fungal Cavern","-","SB+","-","12.44%","Mush",10719
-"Fungal Cavern","-","SB+","-","11.82%","Quillback",10719
-"Fungal Cavern","-","SB+","-","11.75%","Floating Spore",10719
-"Fungal Cavern","-","SB+","-","8.62%","Mushroom Sprite",10719
-"Fungal Cavern","-","SB+","-","8.13%","Bitter Root",10719
-"Fungal Cavern","-","SB+","-","7.90%","Nightshade Masquerade",10719
-"Fungal Cavern","-","SB+","-","6.94%","Spiked Burrower",10719
-"Fungal Cavern","-","SB+","-","1.85%","Sporeticus",10719
-"Fungal Cavern","-","SB+","-","1.05%","Mouldy Mole",10719
-"Fungal Cavern","-","SB+","-","0.79%","Spore Muncher",10719
-"Fungal Cavern","-","Gouda","-","15.03%","Funglore",25548
-"Fungal Cavern","-","Gouda","-","15.02%","Mush",25548
-"Fungal Cavern","-","Gouda","-","13.60%","Lumahead",25548
-"Fungal Cavern","-","Gouda","-","13.59%","Floating Spore",25548
-"Fungal Cavern","-","Gouda","-","12.06%","Quillback",25548
-"Fungal Cavern","-","Gouda","-","9.82%","Mushroom Sprite",25548
-"Fungal Cavern","-","Gouda","-","8.13%","Bitter Root",25548
-"Fungal Cavern","-","Gouda","-","6.87%","Spiked Burrower",25548
-"Fungal Cavern","-","Gouda","-","2.02%","Mouldy Mole",25548
-"Fungal Cavern","-","Gouda","-","1.94%","Spore Muncher",25548
-"Fungal Cavern","-","Gouda","-","1.92%","Sporeticus",25548
-"Fungal Cavern","-","Brie","-","13.75%","Mush",2363
-"Fungal Cavern","-","Brie","-","13.08%","Quillback",2363
-"Fungal Cavern","-","Brie","-","11.47%","Lumahead",2363
-"Fungal Cavern","-","Brie","-","10.58%","Floating Spore",2363
-"Fungal Cavern","-","Brie","-","10.37%","Funglore",2363
-"Fungal Cavern","-","Brie","-","9.06%","Mushroom Sprite",2363
-"Fungal Cavern","-","Brie","-","8.13%","Bitter Root",2363
-"Fungal Cavern","-","Brie","-","7.19%","Spiked Burrower",2363
-"Fungal Cavern","-","Brie","-","6.01%","Sporeticus",2363
-"Fungal Cavern","-","Brie","-","5.25%","Spore Muncher",2363
-"Fungal Cavern","-","Brie","-","5.12%","Mouldy Mole",2363
-"Fungal Cavern","-","Glowing Gruyere","-","20.13%","Crag Elder",28949
-"Fungal Cavern","-","Glowing Gruyere","-","19.76%","Stone Maiden",28949
-"Fungal Cavern","-","Glowing Gruyere","-","17.80%","Dirt Thing",28949
-"Fungal Cavern","-","Glowing Gruyere","-","17.57%","Crystalline Slasher",28949
-"Fungal Cavern","-","Glowing Gruyere","-","12.86%","Cavern Crumbler",28949
-"Fungal Cavern","-","Glowing Gruyere","-","6.02%","Shattered Obsidian",28949
-"Fungal Cavern","-","Glowing Gruyere","-","3.87%","Splintered Stone Sentry",28949
-"Fungal Cavern","-","Glowing Gruyere","-","2.00%","Gemstone Worshipper",28949
-"Fungal Cavern","-","Mineral","-","28.38%","Gemorpher",14380
-"Fungal Cavern","-","Mineral","-","24.14%","Crystal Controller",14380
-"Fungal Cavern","-","Mineral","-","23.63%","Crystalback",14380
-"Fungal Cavern","-","Mineral","-","14.82%","Stalagmite",14380
-"Fungal Cavern","-","Mineral","-","6.06%","Crystal Cave Worm",14380
-"Fungal Cavern","-","Mineral","-","1.02%","Crystal Observer",14380
-"Fungal Cavern","-","Mineral","-","1.01%","Crystal Lurker",14380
-"Fungal Cavern","-","Mineral","-","0.94%","Crystal Queen",14380
-"Fungal Cavern","-","Gemstone","-","37.11%","Crystal Queen",11979
-"Fungal Cavern","-","Gemstone","-","29.56%","Crystal Lurker",11979
-"Fungal Cavern","-","Gemstone","-","24.68%","Crystal Observer",11979
-"Fungal Cavern","-","Gemstone","-","6.75%","Crystal Golem",11979
-"Fungal Cavern","-","Gemstone","-","0.95%","Huntereater",11979
-"Fungal Cavern","-","Gemstone","-","0.95%","Diamondhide",11979
-"Fungal Cavern","-","Diamond","-","66.69%","Crystal Behemoth",1774
-"Fungal Cavern","-","Diamond","-","25.37%","Huntereater",1774
-"Fungal Cavern","-","Diamond","-","7.95%","Diamondhide",1774
+"Fungal Cavern","-","SB+","-","14.52%","Funglore",11692
+"Fungal Cavern","-","SB+","-","14.21%","Lumahead",11692
+"Fungal Cavern","-","SB+","-","12.44%","Mush",11692
+"Fungal Cavern","-","SB+","-","11.85%","Floating Spore",11692
+"Fungal Cavern","-","SB+","-","11.66%","Quillback",11692
+"Fungal Cavern","-","SB+","-","8.64%","Mushroom Sprite",11692
+"Fungal Cavern","-","SB+","-","8.16%","Bitter Root",11692
+"Fungal Cavern","-","SB+","-","7.89%","Nightshade Masquerade",11692
+"Fungal Cavern","-","SB+","-","6.97%","Spiked Burrower",11692
+"Fungal Cavern","-","SB+","-","1.80%","Sporeticus",11692
+"Fungal Cavern","-","SB+","-","1.06%","Mouldy Mole",11692
+"Fungal Cavern","-","SB+","-","0.80%","Spore Muncher",11692
+"Fungal Cavern","-","Gouda","-","14.95%","Funglore",28247
+"Fungal Cavern","-","Gouda","-","14.86%","Mush",28247
+"Fungal Cavern","-","Gouda","-","13.67%","Floating Spore",28247
+"Fungal Cavern","-","Gouda","-","13.58%","Lumahead",28247
+"Fungal Cavern","-","Gouda","-","12.13%","Quillback",28247
+"Fungal Cavern","-","Gouda","-","9.92%","Mushroom Sprite",28247
+"Fungal Cavern","-","Gouda","-","8.17%","Bitter Root",28247
+"Fungal Cavern","-","Gouda","-","6.88%","Spiked Burrower",28247
+"Fungal Cavern","-","Gouda","-","2.03%","Mouldy Mole",28247
+"Fungal Cavern","-","Gouda","-","1.92%","Spore Muncher",28247
+"Fungal Cavern","-","Gouda","-","1.90%","Sporeticus",28247
+"Fungal Cavern","-","Brie","-","13.56%","Mush",2514
+"Fungal Cavern","-","Brie","-","13.13%","Quillback",2514
+"Fungal Cavern","-","Brie","-","11.50%","Lumahead",2514
+"Fungal Cavern","-","Brie","-","10.62%","Floating Spore",2514
+"Fungal Cavern","-","Brie","-","10.34%","Funglore",2514
+"Fungal Cavern","-","Brie","-","8.87%","Mushroom Sprite",2514
+"Fungal Cavern","-","Brie","-","8.27%","Bitter Root",2514
+"Fungal Cavern","-","Brie","-","7.24%","Spiked Burrower",2514
+"Fungal Cavern","-","Brie","-","5.93%","Sporeticus",2514
+"Fungal Cavern","-","Brie","-","5.29%","Mouldy Mole",2514
+"Fungal Cavern","-","Brie","-","5.25%","Spore Muncher",2514
+"Fungal Cavern","-","Glowing Gruyere","-","20.07%","Crag Elder",31362
+"Fungal Cavern","-","Glowing Gruyere","-","19.79%","Stone Maiden",31362
+"Fungal Cavern","-","Glowing Gruyere","-","17.80%","Dirt Thing",31362
+"Fungal Cavern","-","Glowing Gruyere","-","17.67%","Crystalline Slasher",31362
+"Fungal Cavern","-","Glowing Gruyere","-","12.86%","Cavern Crumbler",31362
+"Fungal Cavern","-","Glowing Gruyere","-","5.98%","Shattered Obsidian",31362
+"Fungal Cavern","-","Glowing Gruyere","-","3.87%","Splintered Stone Sentry",31362
+"Fungal Cavern","-","Glowing Gruyere","-","1.97%","Gemstone Worshipper",31362
+"Fungal Cavern","-","Mineral","-","28.39%","Gemorpher",15943
+"Fungal Cavern","-","Mineral","-","24.27%","Crystal Controller",15943
+"Fungal Cavern","-","Mineral","-","23.49%","Crystalback",15943
+"Fungal Cavern","-","Mineral","-","14.81%","Stalagmite",15943
+"Fungal Cavern","-","Mineral","-","6.12%","Crystal Cave Worm",15943
+"Fungal Cavern","-","Mineral","-","0.99%","Crystal Lurker",15943
+"Fungal Cavern","-","Mineral","-","0.99%","Crystal Observer",15943
+"Fungal Cavern","-","Mineral","-","0.94%","Crystal Queen",15943
+"Fungal Cavern","-","Gemstone","-","37.36%","Crystal Queen",13018
+"Fungal Cavern","-","Gemstone","-","29.37%","Crystal Lurker",13018
+"Fungal Cavern","-","Gemstone","-","24.67%","Crystal Observer",13018
+"Fungal Cavern","-","Gemstone","-","6.66%","Crystal Golem",13018
+"Fungal Cavern","-","Gemstone","-","1.00%","Diamondhide",13018
+"Fungal Cavern","-","Gemstone","-","0.94%","Huntereater",13018
+"Fungal Cavern","-","Diamond","-","67.12%","Crystal Behemoth",2044
+"Fungal Cavern","-","Diamond","-","24.76%","Huntereater",2044
+"Fungal Cavern","-","Diamond","-","8.12%","Diamondhide",2044

--- a/data/pop-csv/furoma-rift.csv
+++ b/data/pop-csv/furoma-rift.csv
@@ -1,88 +1,97 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Furoma Rift","Training Grounds","Maki String","-","25.70%","Shinobi",1428
-"Furoma Rift","Training Grounds","Maki String","-","22.06%","Armored Archer",1428
-"Furoma Rift","Training Grounds","Maki String","-","12.04%","Dumpling Delivery",1428
-"Furoma Rift","Training Grounds","Maki String","-","11.55%","Wealth",1428
-"Furoma Rift","Training Grounds","Maki String","-","10.92%","Enlightened Labourer",1428
-"Furoma Rift","Training Grounds","Maki String","-","9.94%","Raw Diamond",1428
-"Furoma Rift","Training Grounds","Maki String","-","3.15%","Shaolin Kung Fu",1428
-"Furoma Rift","Training Grounds","Maki String","-","2.31%","Militant Samurai",1428
-"Furoma Rift","Training Grounds","Maki String","-","2.31%","Wandering Monk",1428
-"Furoma Rift","Training Grounds","Magical String","-","23.87%","Dumpling Delivery",2844
-"Furoma Rift","Training Grounds","Magical String","-","21.87%","Armored Archer",2844
-"Furoma Rift","Training Grounds","Magical String","-","19.37%","Shinobi",2844
-"Furoma Rift","Training Grounds","Magical String","-","11.08%","Wealth",2844
-"Furoma Rift","Training Grounds","Magical String","-","9.88%","Raw Diamond",2844
-"Furoma Rift","Training Grounds","Magical String","-","5.06%","Enlightened Labourer",2844
-"Furoma Rift","Training Grounds","Magical String","-","3.62%","Shaolin Kung Fu",2844
-"Furoma Rift","Training Grounds","Magical String","-","3.23%","Wandering Monk",2844
-"Furoma Rift","Training Grounds","Magical String","-","2.00%","Militant Samurai",2844
-"Furoma Rift","Training Grounds","Brie String","-","24.87%","Armored Archer",43527
-"Furoma Rift","Training Grounds","Brie String","-","23.82%","Dumpling Delivery",43527
-"Furoma Rift","Training Grounds","Brie String","-","22.65%","Shinobi",43527
-"Furoma Rift","Training Grounds","Brie String","-","8.05%","Raw Diamond",43527
-"Furoma Rift","Training Grounds","Brie String","-","4.98%","Wealth",43527
-"Furoma Rift","Training Grounds","Brie String","-","4.81%","Rift Guardian",43527
-"Furoma Rift","Training Grounds","Brie String","-","4.01%","Shaolin Kung Fu",43527
-"Furoma Rift","Training Grounds","Brie String","-","2.88%","Wandering Monk",43527
-"Furoma Rift","Training Grounds","Brie String","-","1.99%","Militant Samurai",43527
-"Furoma Rift","Training Grounds","Brie String","-","1.94%","Enlightened Labourer",43527
-"Furoma Rift","Training Grounds","Swiss String","-","20.63%","Armored Archer",2772
-"Furoma Rift","Training Grounds","Swiss String","-","20.31%","Shinobi",2772
-"Furoma Rift","Training Grounds","Swiss String","-","15.15%","Dumpling Delivery",2772
-"Furoma Rift","Training Grounds","Swiss String","-","10.61%","Rift Guardian",2772
-"Furoma Rift","Training Grounds","Swiss String","-","9.49%","Brawny",2772
-"Furoma Rift","Training Grounds","Swiss String","-","9.05%","Wealth",2772
-"Furoma Rift","Training Grounds","Swiss String","-","5.12%","Raw Diamond",2772
-"Furoma Rift","Training Grounds","Swiss String","-","4.29%","Shaolin Kung Fu",2772
-"Furoma Rift","Training Grounds","Swiss String","-","3.50%","Wandering Monk",2772
-"Furoma Rift","Training Grounds","Swiss String","-","1.84%","Militant Samurai",2772
-"Furoma Rift","Pagoda","Maki String","-","19.96%","Student of the Chi Claw",42447
-"Furoma Rift","Pagoda","Maki String","-","19.88%","Student of the Chi Belt",42447
-"Furoma Rift","Pagoda","Maki String","-","19.58%","Student of the Chi Fang",42447
-"Furoma Rift","Pagoda","Maki String","-","11.95%","Shaolin Kung Fu",42447
-"Furoma Rift","Pagoda","Maki String","-","6.84%","Wandering Monk",42447
-"Furoma Rift","Pagoda","Maki String","-","5.94%","Dancing Assassin",42447
-"Furoma Rift","Pagoda","Maki String","-","5.89%","Shinobi",42447
-"Furoma Rift","Pagoda","Maki String","-","4.93%","Militant Samurai",42447
-"Furoma Rift","Pagoda","Maki String","-","2.94%","Wealth",42447
-"Furoma Rift","Pagoda","Maki String","-","2.08%","Raw Diamond",42447
-"Furoma Rift","Pagoda","Magical String","-","15.26%","Student of the Chi Fang",1782
-"Furoma Rift","Pagoda","Magical String","-","14.81%","Student of the Chi Belt",1782
-"Furoma Rift","Pagoda","Magical String","-","14.42%","Student of the Chi Claw",1782
-"Furoma Rift","Pagoda","Magical String","-","12.74%","Wandering Monk",1782
-"Furoma Rift","Pagoda","Magical String","-","11.28%","Shaolin Kung Fu",1782
-"Furoma Rift","Pagoda","Magical String","-","10.55%","Militant Samurai",1782
-"Furoma Rift","Pagoda","Magical String","-","8.36%","Shinobi",1782
-"Furoma Rift","Pagoda","Magical String","-","5.05%","Dancing Assassin",1782
-"Furoma Rift","Pagoda","Magical String","-","4.10%","Wealth",1782
-"Furoma Rift","Pagoda","Magical String","-","3.42%","Raw Diamond",1782
-"Furoma Rift","Pagoda","Brie String","-","14.88%","Student of the Chi Belt",65016
-"Furoma Rift","Pagoda","Brie String","-","14.87%","Student of the Chi Fang",65016
-"Furoma Rift","Pagoda","Brie String","-","14.84%","Student of the Chi Claw",65016
-"Furoma Rift","Pagoda","Brie String","-","12.11%","Militant Samurai",65016
-"Furoma Rift","Pagoda","Brie String","-","11.76%","Shaolin Kung Fu",65016
-"Furoma Rift","Pagoda","Brie String","-","11.61%","Wandering Monk",65016
-"Furoma Rift","Pagoda","Brie String","-","9.01%","Shinobi",65016
-"Furoma Rift","Pagoda","Brie String","-","3.97%","Wealth",65016
-"Furoma Rift","Pagoda","Brie String","-","3.92%","Dancing Assassin",65016
-"Furoma Rift","Pagoda","Brie String","-","3.02%","Raw Diamond",65016
-"Furoma Rift","Pagoda","Swiss String","-","18.74%","Militant Samurai",555
-"Furoma Rift","Pagoda","Swiss String","-","18.20%","Wandering Monk",555
-"Furoma Rift","Pagoda","Swiss String","-","12.79%","Shaolin Kung Fu",555
-"Furoma Rift","Pagoda","Swiss String","-","11.35%","Shinobi",555
-"Furoma Rift","Pagoda","Swiss String","-","9.37%","Student of the Chi Fang",555
-"Furoma Rift","Pagoda","Swiss String","-","9.19%","Student of the Chi Belt",555
-"Furoma Rift","Pagoda","Swiss String","-","6.85%","Student of the Chi Claw",555
-"Furoma Rift","Pagoda","Swiss String","-","6.31%","Wealth",555
-"Furoma Rift","Pagoda","Swiss String","-","4.32%","Dancing Assassin",555
-"Furoma Rift","Pagoda","Swiss String","-","2.88%","Raw Diamond",555
-"Furoma Rift","Pagoda","Master Fusion","-","34.21%","Master of the Chi Fang",30820
-"Furoma Rift","Pagoda","Master Fusion","-","32.94%","Master of the Chi Belt",30820
-"Furoma Rift","Pagoda","Master Fusion","-","32.85%","Master of the Chi Claw",30820
-"Furoma Rift","Pagoda","Rift Combat","-","100.00%","Master of the Chi Fang",7481
-"Furoma Rift","Pagoda","Rift Glutter","-","100.00%","Master of the Chi Belt",7367
-"Furoma Rift","Pagoda","Rift Susheese","-","100.00%","Master of the Chi Claw",7690
-"Furoma Rift","Pagoda","Rift Rumble","-","100.00%","Grand Master of the Dojo",31539
-"Furoma Rift","Pagoda","Null Onyx Gorgonzola","-","100.00%","Supreme Sensei",15890
-"Furoma Rift","Pagoda","Ascended","-","100.00%","Ascended Elder",5150
+"Furoma Rift","Training Grounds","Maki String","-","24.26%","Shinobi",2040
+"Furoma Rift","Training Grounds","Maki String","-","23.14%","Armored Archer",2040
+"Furoma Rift","Training Grounds","Maki String","-","11.76%","Dumpling Delivery",2040
+"Furoma Rift","Training Grounds","Maki String","-","11.23%","Wealth",2040
+"Furoma Rift","Training Grounds","Maki String","-","10.98%","Enlightened Labourer",2040
+"Furoma Rift","Training Grounds","Maki String","-","10.25%","Raw Diamond",2040
+"Furoma Rift","Training Grounds","Maki String","-","3.38%","Shaolin Kung Fu",2040
+"Furoma Rift","Training Grounds","Maki String","-","2.84%","Wandering Monk",2040
+"Furoma Rift","Training Grounds","Maki String","-","2.16%","Militant Samurai",2040
+"Furoma Rift","Training Grounds","Magical String","-","24.07%","Dumpling Delivery",4816
+"Furoma Rift","Training Grounds","Magical String","-","21.97%","Armored Archer",4816
+"Furoma Rift","Training Grounds","Magical String","-","19.71%","Shinobi",4816
+"Furoma Rift","Training Grounds","Magical String","-","10.57%","Wealth",4816
+"Furoma Rift","Training Grounds","Magical String","-","9.70%","Raw Diamond",4816
+"Furoma Rift","Training Grounds","Magical String","-","5.25%","Enlightened Labourer",4816
+"Furoma Rift","Training Grounds","Magical String","-","3.70%","Shaolin Kung Fu",4816
+"Furoma Rift","Training Grounds","Magical String","-","2.87%","Wandering Monk",4816
+"Furoma Rift","Training Grounds","Magical String","-","2.18%","Militant Samurai",4816
+"Furoma Rift","Training Grounds","Brie String","-","24.91%","Armored Archer",61252
+"Furoma Rift","Training Grounds","Brie String","-","23.85%","Dumpling Delivery",61252
+"Furoma Rift","Training Grounds","Brie String","-","22.69%","Shinobi",61252
+"Furoma Rift","Training Grounds","Brie String","-","7.89%","Raw Diamond",61252
+"Furoma Rift","Training Grounds","Brie String","-","4.95%","Wealth",61252
+"Furoma Rift","Training Grounds","Brie String","-","4.89%","Rift Guardian",61252
+"Furoma Rift","Training Grounds","Brie String","-","4.05%","Shaolin Kung Fu",61252
+"Furoma Rift","Training Grounds","Brie String","-","2.86%","Wandering Monk",61252
+"Furoma Rift","Training Grounds","Brie String","-","1.97%","Militant Samurai",61252
+"Furoma Rift","Training Grounds","Brie String","-","1.96%","Enlightened Labourer",61252
+"Furoma Rift","Training Grounds","Swiss String","-","20.71%","Shinobi",3360
+"Furoma Rift","Training Grounds","Swiss String","-","20.68%","Armored Archer",3360
+"Furoma Rift","Training Grounds","Swiss String","-","15.15%","Dumpling Delivery",3360
+"Furoma Rift","Training Grounds","Swiss String","-","10.51%","Rift Guardian",3360
+"Furoma Rift","Training Grounds","Swiss String","-","9.29%","Brawny",3360
+"Furoma Rift","Training Grounds","Swiss String","-","9.05%","Wealth",3360
+"Furoma Rift","Training Grounds","Swiss String","-","5.00%","Raw Diamond",3360
+"Furoma Rift","Training Grounds","Swiss String","-","4.38%","Shaolin Kung Fu",3360
+"Furoma Rift","Training Grounds","Swiss String","-","3.33%","Wandering Monk",3360
+"Furoma Rift","Training Grounds","Swiss String","-","1.90%","Militant Samurai",3360
+"Furoma Rift","Training Grounds","Marble String","-","21.11%","Armored Archer",180
+"Furoma Rift","Training Grounds","Marble String","-","18.33%","Dumpling Delivery",180
+"Furoma Rift","Training Grounds","Marble String","-","16.67%","Shinobi",180
+"Furoma Rift","Training Grounds","Marble String","-","13.33%","Rift Guardian",180
+"Furoma Rift","Training Grounds","Marble String","-","12.78%","Brawny",180
+"Furoma Rift","Training Grounds","Marble String","-","6.67%","Shaolin Kung Fu",180
+"Furoma Rift","Training Grounds","Marble String","-","6.11%","Raw Diamond",180
+"Furoma Rift","Training Grounds","Marble String","-","2.78%","Wealth",180
+"Furoma Rift","Training Grounds","Marble String","-","2.22%","Wandering Monk",180
+"Furoma Rift","Pagoda","Maki String","-","19.81%","Student of the Chi Claw",57212
+"Furoma Rift","Pagoda","Maki String","-","19.80%","Student of the Chi Belt",57212
+"Furoma Rift","Pagoda","Maki String","-","19.60%","Student of the Chi Fang",57212
+"Furoma Rift","Pagoda","Maki String","-","12.00%","Shaolin Kung Fu",57212
+"Furoma Rift","Pagoda","Maki String","-","6.95%","Wandering Monk",57212
+"Furoma Rift","Pagoda","Maki String","-","5.96%","Dancing Assassin",57212
+"Furoma Rift","Pagoda","Maki String","-","5.95%","Shinobi",57212
+"Furoma Rift","Pagoda","Maki String","-","4.87%","Militant Samurai",57212
+"Furoma Rift","Pagoda","Maki String","-","2.96%","Wealth",57212
+"Furoma Rift","Pagoda","Maki String","-","2.09%","Raw Diamond",57212
+"Furoma Rift","Pagoda","Magical String","-","15.23%","Student of the Chi Fang",2962
+"Furoma Rift","Pagoda","Magical String","-","14.58%","Student of the Chi Claw",2962
+"Furoma Rift","Pagoda","Magical String","-","14.01%","Student of the Chi Belt",2962
+"Furoma Rift","Pagoda","Magical String","-","12.63%","Wandering Monk",2962
+"Furoma Rift","Pagoda","Magical String","-","11.92%","Shaolin Kung Fu",2962
+"Furoma Rift","Pagoda","Magical String","-","11.51%","Militant Samurai",2962
+"Furoma Rift","Pagoda","Magical String","-","8.10%","Shinobi",2962
+"Furoma Rift","Pagoda","Magical String","-","5.00%","Dancing Assassin",2962
+"Furoma Rift","Pagoda","Magical String","-","3.92%","Wealth",2962
+"Furoma Rift","Pagoda","Magical String","-","3.11%","Raw Diamond",2962
+"Furoma Rift","Pagoda","Brie String","-","14.93%","Student of the Chi Belt",83469
+"Furoma Rift","Pagoda","Brie String","-","14.80%","Student of the Chi Claw",83469
+"Furoma Rift","Pagoda","Brie String","-","14.79%","Student of the Chi Fang",83469
+"Furoma Rift","Pagoda","Brie String","-","12.11%","Militant Samurai",83469
+"Furoma Rift","Pagoda","Brie String","-","11.86%","Shaolin Kung Fu",83469
+"Furoma Rift","Pagoda","Brie String","-","11.64%","Wandering Monk",83469
+"Furoma Rift","Pagoda","Brie String","-","9.01%","Shinobi",83469
+"Furoma Rift","Pagoda","Brie String","-","3.94%","Wealth",83469
+"Furoma Rift","Pagoda","Brie String","-","3.89%","Dancing Assassin",83469
+"Furoma Rift","Pagoda","Brie String","-","3.02%","Raw Diamond",83469
+"Furoma Rift","Pagoda","Swiss String","-","18.92%","Militant Samurai",761
+"Furoma Rift","Pagoda","Swiss String","-","18.13%","Wandering Monk",761
+"Furoma Rift","Pagoda","Swiss String","-","12.09%","Shaolin Kung Fu",761
+"Furoma Rift","Pagoda","Swiss String","-","10.64%","Shinobi",761
+"Furoma Rift","Pagoda","Swiss String","-","9.99%","Student of the Chi Belt",761
+"Furoma Rift","Pagoda","Swiss String","-","8.94%","Student of the Chi Fang",761
+"Furoma Rift","Pagoda","Swiss String","-","7.36%","Student of the Chi Claw",761
+"Furoma Rift","Pagoda","Swiss String","-","6.57%","Wealth",761
+"Furoma Rift","Pagoda","Swiss String","-","4.34%","Dancing Assassin",761
+"Furoma Rift","Pagoda","Swiss String","-","3.02%","Raw Diamond",761
+"Furoma Rift","Pagoda","Master Fusion","-","34.10%","Master of the Chi Fang",46269
+"Furoma Rift","Pagoda","Master Fusion","-","33.13%","Master of the Chi Belt",46269
+"Furoma Rift","Pagoda","Master Fusion","-","32.78%","Master of the Chi Claw",46269
+"Furoma Rift","Pagoda","Rift Combat","-","100.00%","Master of the Chi Fang",9996
+"Furoma Rift","Pagoda","Rift Glutter","-","100.00%","Master of the Chi Belt",10048
+"Furoma Rift","Pagoda","Rift Susheese","-","100.00%","Master of the Chi Claw",10650
+"Furoma Rift","Pagoda","Rift Rumble","-","100.00%","Grand Master of the Dojo",49823
+"Furoma Rift","Pagoda","Null Onyx Gorgonzola","-","100.00%","Supreme Sensei",23740
+"Furoma Rift","Pagoda","Ascended","-","100.00%","Ascended Elder",9032

--- a/data/pop-csv/laboratory.csv
+++ b/data/pop-csv/laboratory.csv
@@ -1,26 +1,24 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Laboratory","-","Radioactive Blue","-","32.73%","Monster",2835
-"Laboratory","-","Radioactive Blue","-","25.96%","Mutated White",2835
-"Laboratory","-","Radioactive Blue","-","25.50%","Mutated Grey",2835
-"Laboratory","-","Radioactive Blue","-","15.63%","Mutated Brown",2835
-"Laboratory","-","Radioactive Blue","-","0.18%","Black Widow",2835
-"Laboratory","-","Limelight","-","100.00%","Mutated Mole",1355
 "Laboratory","-","SB+","-","27.19%","Sludge Scientist",2755
 "Laboratory","-","SB+","-","24.32%","Clumsy Chemist",2755
 "Laboratory","-","SB+","-","23.41%","Squeaker Bot",2755
 "Laboratory","-","SB+","-","16.52%","Bionic",2755
 "Laboratory","-","SB+","-","8.20%","Burglar",2755
 "Laboratory","-","SB+","-","0.36%","Black Widow",2755
-"Laboratory","-","Gouda","-","31.26%","Sludge Scientist",1369
-"Laboratory","-","Gouda","-","30.75%","Squeaker Bot",1369
-"Laboratory","-","Gouda","-","22.94%","Bionic",1369
-"Laboratory","-","Gouda","-","11.54%","Clumsy Chemist",1369
-"Laboratory","-","Gouda","-","3.51%","Burglar",1369
 "Laboratory","-","Brie","-","29.05%","Squeaker Bot",1401
 "Laboratory","-","Brie","-","28.98%","Bionic",1401
 "Laboratory","-","Brie","-","28.27%","Sludge Scientist",1401
 "Laboratory","-","Brie","-","8.42%","Clumsy Chemist",1401
 "Laboratory","-","Brie","-","5.28%","Burglar",1401
+"Laboratory","-","Gouda","-","32.40%","Sludge Scientist",1321
+"Laboratory","-","Gouda","-","31.87%","Squeaker Bot",1321
+"Laboratory","-","Gouda","-","23.77%","Bionic",1321
+"Laboratory","-","Gouda","-","11.96%","Clumsy Chemist",1321
+"Laboratory","-","Radioactive Blue","-","32.73%","Monster",2835
+"Laboratory","-","Radioactive Blue","-","25.96%","Mutated White",2835
+"Laboratory","-","Radioactive Blue","-","25.50%","Mutated Grey",2835
+"Laboratory","-","Radioactive Blue","-","15.63%","Mutated Brown",2835
+"Laboratory","-","Radioactive Blue","-","0.18%","Black Widow",2835
 "Laboratory","-","Rancid Radioactive Blue","-","31.32%","Mutated White",3697
 "Laboratory","-","Rancid Radioactive Blue","-","25.37%","Monster",3697
 "Laboratory","-","Rancid Radioactive Blue","-","24.15%","Mutated Grey",3697
@@ -31,3 +29,4 @@
 "Laboratory","-","Magical Rancid Radioactive Blue","-","16.17%","Mutated White",1886
 "Laboratory","-","Magical Rancid Radioactive Blue","-","14.90%","Mutated Brown",1886
 "Laboratory","-","Magical Rancid Radioactive Blue","-","1.86%","Black Widow",1886
+"Laboratory","-","Limelight","-","100.00%","Mutated Mole",1355

--- a/data/pop-csv/laboratory.csv
+++ b/data/pop-csv/laboratory.csv
@@ -1,33 +1,33 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Laboratory","-","Radioactive Blue","-","32.59%","Monster",1120
-"Laboratory","-","Radioactive Blue","-","25.45%","Mutated Grey",1120
-"Laboratory","-","Radioactive Blue","-","25.18%","Mutated White",1120
-"Laboratory","-","Radioactive Blue","-","16.70%","Mutated Brown",1120
-"Laboratory","-","Radioactive Blue","-","0.09%","Black Widow",1120
-"Laboratory","-","Limelight","-","100.00%","Mutated Mole",889
-"Laboratory","-","SB+","-","28.64%","Sludge Scientist",1571
-"Laboratory","-","SB+","-","24.06%","Squeaker Bot",1571
-"Laboratory","-","SB+","-","23.93%","Clumsy Chemist",1571
-"Laboratory","-","SB+","-","16.23%","Bionic",1571
-"Laboratory","-","SB+","-","6.81%","Burglar",1571
-"Laboratory","-","SB+","-","0.32%","Black Widow",1571
-"Laboratory","-","Gouda","-","30.29%","Sludge Scientist",875
-"Laboratory","-","Gouda","-","28.46%","Squeaker Bot",875
-"Laboratory","-","Gouda","-","24.11%","Bionic",875
-"Laboratory","-","Gouda","-","11.89%","Clumsy Chemist",875
-"Laboratory","-","Gouda","-","5.26%","Burglar",875
-"Laboratory","-","Brie","-","28.96%","Sludge Scientist",701
-"Laboratory","-","Brie","-","28.53%","Bionic",701
-"Laboratory","-","Brie","-","28.53%","Squeaker Bot",701
-"Laboratory","-","Brie","-","8.56%","Clumsy Chemist",701
-"Laboratory","-","Brie","-","5.42%","Burglar",701
-"Laboratory","-","Rancid Radioactive Blue","-","29.48%","Mutated White",1893
-"Laboratory","-","Rancid Radioactive Blue","-","25.94%","Monster",1893
-"Laboratory","-","Rancid Radioactive Blue","-","23.93%","Mutated Grey",1893
-"Laboratory","-","Rancid Radioactive Blue","-","19.60%","Mutated Brown",1893
-"Laboratory","-","Rancid Radioactive Blue","-","1.06%","Black Widow",1893
-"Laboratory","-","Magical Rancid Radioactive Blue","-","50.25%","Monster",790
-"Laboratory","-","Magical Rancid Radioactive Blue","-","17.72%","Mutated Grey",790
-"Laboratory","-","Magical Rancid Radioactive Blue","-","16.08%","Mutated White",790
-"Laboratory","-","Magical Rancid Radioactive Blue","-","14.43%","Mutated Brown",790
-"Laboratory","-","Magical Rancid Radioactive Blue","-","1.52%","Black Widow",790
+"Laboratory","-","Radioactive Blue","-","32.73%","Monster",2835
+"Laboratory","-","Radioactive Blue","-","25.96%","Mutated White",2835
+"Laboratory","-","Radioactive Blue","-","25.50%","Mutated Grey",2835
+"Laboratory","-","Radioactive Blue","-","15.63%","Mutated Brown",2835
+"Laboratory","-","Radioactive Blue","-","0.18%","Black Widow",2835
+"Laboratory","-","Limelight","-","100.00%","Mutated Mole",1355
+"Laboratory","-","SB+","-","27.19%","Sludge Scientist",2755
+"Laboratory","-","SB+","-","24.32%","Clumsy Chemist",2755
+"Laboratory","-","SB+","-","23.41%","Squeaker Bot",2755
+"Laboratory","-","SB+","-","16.52%","Bionic",2755
+"Laboratory","-","SB+","-","8.20%","Burglar",2755
+"Laboratory","-","SB+","-","0.36%","Black Widow",2755
+"Laboratory","-","Gouda","-","31.26%","Sludge Scientist",1369
+"Laboratory","-","Gouda","-","30.75%","Squeaker Bot",1369
+"Laboratory","-","Gouda","-","22.94%","Bionic",1369
+"Laboratory","-","Gouda","-","11.54%","Clumsy Chemist",1369
+"Laboratory","-","Gouda","-","3.51%","Burglar",1369
+"Laboratory","-","Brie","-","29.05%","Squeaker Bot",1401
+"Laboratory","-","Brie","-","28.98%","Bionic",1401
+"Laboratory","-","Brie","-","28.27%","Sludge Scientist",1401
+"Laboratory","-","Brie","-","8.42%","Clumsy Chemist",1401
+"Laboratory","-","Brie","-","5.28%","Burglar",1401
+"Laboratory","-","Rancid Radioactive Blue","-","31.32%","Mutated White",3697
+"Laboratory","-","Rancid Radioactive Blue","-","25.37%","Monster",3697
+"Laboratory","-","Rancid Radioactive Blue","-","24.15%","Mutated Grey",3697
+"Laboratory","-","Rancid Radioactive Blue","-","18.04%","Mutated Brown",3697
+"Laboratory","-","Rancid Radioactive Blue","-","1.11%","Black Widow",3697
+"Laboratory","-","Magical Rancid Radioactive Blue","-","48.36%","Monster",1886
+"Laboratory","-","Magical Rancid Radioactive Blue","-","18.72%","Mutated Grey",1886
+"Laboratory","-","Magical Rancid Radioactive Blue","-","16.17%","Mutated White",1886
+"Laboratory","-","Magical Rancid Radioactive Blue","-","14.90%","Mutated Brown",1886
+"Laboratory","-","Magical Rancid Radioactive Blue","-","1.86%","Black Widow",1886

--- a/data/pop-csv/living-garden.csv
+++ b/data/pop-csv/living-garden.csv
@@ -1,46 +1,46 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Living Garden","Not Poured","Duskshade Camembert","-","46.97%","Carmine the Apothecary",2161
-"Living Garden","Not Poured","Duskshade Camembert","-","34.89%","Shroom",2161
-"Living Garden","Not Poured","Duskshade Camembert","-","18.14%","Camoflower",2161
-"Living Garden","Not Poured","SB+","-","23.80%","Strawberry Hotcakes",1752
-"Living Garden","Not Poured","SB+","-","22.09%","Thistle",1752
-"Living Garden","Not Poured","SB+","-","17.35%","Bark",1752
-"Living Garden","Not Poured","SB+","-","15.64%","Calalilly",1752
-"Living Garden","Not Poured","SB+","-","13.58%","Shroom",1752
-"Living Garden","Not Poured","SB+","-","7.53%","Camoflower",1752
-"Living Garden","Not Poured","Gouda","-","26.74%","Thistle",9950
-"Living Garden","Not Poured","Gouda","-","21.90%","Bark",9950
-"Living Garden","Not Poured","Gouda","-","17.59%","Calalilly",9950
-"Living Garden","Not Poured","Gouda","-","15.57%","Shroom",9950
-"Living Garden","Not Poured","Gouda","-","10.37%","Strawberry Hotcakes",9950
-"Living Garden","Not Poured","Gouda","-","7.83%","Camoflower",9950
-"Living Garden","Not Poured","Brie","-","26.36%","Thistle",660
-"Living Garden","Not Poured","Brie","-","20.91%","Bark",660
-"Living Garden","Not Poured","Brie","-","18.94%","Calalilly",660
-"Living Garden","Not Poured","Brie","-","15.30%","Shroom",660
-"Living Garden","Not Poured","Brie","-","10.00%","Strawberry Hotcakes",660
-"Living Garden","Not Poured","Brie","-","8.48%","Camoflower",660
-"Living Garden","Poured","Duskshade Camembert","-","51.38%","Carmine the Apothecary",1236
-"Living Garden","Poured","Duskshade Camembert","-","32.04%","Shroom",1236
-"Living Garden","Poured","Duskshade Camembert","-","16.59%","Camoflower",1236
-"Living Garden","Poured","SB+","-","21.77%","Thistle",1470
-"Living Garden","Poured","SB+","-","19.93%","Strawberry Hotcakes",1470
-"Living Garden","Poured","SB+","-","16.05%","Calalilly",1470
-"Living Garden","Poured","SB+","-","15.44%","Bark",1470
-"Living Garden","Poured","SB+","-","11.90%","Shroom",1470
-"Living Garden","Poured","SB+","-","8.84%","Thirsty",1470
-"Living Garden","Poured","SB+","-","6.05%","Camoflower",1470
-"Living Garden","Poured","Gouda","-","24.05%","Thistle",6001
-"Living Garden","Poured","Gouda","-","20.15%","Bark",6001
-"Living Garden","Poured","Gouda","-","16.61%","Calalilly",6001
-"Living Garden","Poured","Gouda","-","14.68%","Shroom",6001
-"Living Garden","Poured","Gouda","-","9.68%","Thirsty",6001
-"Living Garden","Poured","Gouda","-","8.13%","Strawberry Hotcakes",6001
-"Living Garden","Poured","Gouda","-","6.70%","Camoflower",6001
-"Living Garden","Poured","Brie","-","22.33%","Bark",412
-"Living Garden","Poured","Brie","-","22.09%","Thistle",412
-"Living Garden","Poured","Brie","-","17.72%","Calalilly",412
-"Living Garden","Poured","Brie","-","15.53%","Shroom",412
-"Living Garden","Poured","Brie","-","7.77%","Thirsty",412
-"Living Garden","Poured","Brie","-","7.28%","Strawberry Hotcakes",412
-"Living Garden","Poured","Brie","-","7.28%","Camoflower",412
+"Living Garden","Not Poured","Duskshade Camembert","-","46.80%","Carmine the Apothecary",3263
+"Living Garden","Not Poured","Duskshade Camembert","-","35.00%","Shroom",3263
+"Living Garden","Not Poured","Duskshade Camembert","-","18.20%","Camoflower",3263
+"Living Garden","Not Poured","SB+","-","24.41%","Strawberry Hotcakes",2302
+"Living Garden","Not Poured","SB+","-","22.24%","Thistle",2302
+"Living Garden","Not Poured","SB+","-","16.81%","Bark",2302
+"Living Garden","Not Poured","SB+","-","16.16%","Calalilly",2302
+"Living Garden","Not Poured","SB+","-","13.03%","Shroom",2302
+"Living Garden","Not Poured","SB+","-","7.34%","Camoflower",2302
+"Living Garden","Not Poured","Gouda","-","26.49%","Thistle",13890
+"Living Garden","Not Poured","Gouda","-","21.89%","Bark",13890
+"Living Garden","Not Poured","Gouda","-","17.90%","Calalilly",13890
+"Living Garden","Not Poured","Gouda","-","15.53%","Shroom",13890
+"Living Garden","Not Poured","Gouda","-","10.26%","Strawberry Hotcakes",13890
+"Living Garden","Not Poured","Gouda","-","7.94%","Camoflower",13890
+"Living Garden","Not Poured","Brie","-","26.11%","Thistle",942
+"Living Garden","Not Poured","Brie","-","21.44%","Bark",942
+"Living Garden","Not Poured","Brie","-","19.00%","Calalilly",942
+"Living Garden","Not Poured","Brie","-","16.24%","Shroom",942
+"Living Garden","Not Poured","Brie","-","9.45%","Strawberry Hotcakes",942
+"Living Garden","Not Poured","Brie","-","7.75%","Camoflower",942
+"Living Garden","Poured","Duskshade Camembert","-","52.02%","Carmine the Apothecary",1636
+"Living Garden","Poured","Duskshade Camembert","-","31.97%","Shroom",1636
+"Living Garden","Poured","Duskshade Camembert","-","16.01%","Camoflower",1636
+"Living Garden","Poured","SB+","-","20.93%","Thistle",1777
+"Living Garden","Poured","SB+","-","20.09%","Strawberry Hotcakes",1777
+"Living Garden","Poured","SB+","-","16.38%","Bark",1777
+"Living Garden","Poured","SB+","-","15.14%","Calalilly",1777
+"Living Garden","Poured","SB+","-","11.48%","Shroom",1777
+"Living Garden","Poured","SB+","-","9.57%","Thirsty",1777
+"Living Garden","Poured","SB+","-","6.42%","Camoflower",1777
+"Living Garden","Poured","Gouda","-","24.04%","Thistle",7264
+"Living Garden","Poured","Gouda","-","20.07%","Bark",7264
+"Living Garden","Poured","Gouda","-","16.29%","Calalilly",7264
+"Living Garden","Poured","Gouda","-","14.58%","Shroom",7264
+"Living Garden","Poured","Gouda","-","10.17%","Thirsty",7264
+"Living Garden","Poured","Gouda","-","8.11%","Strawberry Hotcakes",7264
+"Living Garden","Poured","Gouda","-","6.75%","Camoflower",7264
+"Living Garden","Poured","Brie","-","22.84%","Thistle",683
+"Living Garden","Poured","Brie","-","22.55%","Bark",683
+"Living Garden","Poured","Brie","-","16.84%","Calalilly",683
+"Living Garden","Poured","Brie","-","14.49%","Shroom",683
+"Living Garden","Poured","Brie","-","9.08%","Thirsty",683
+"Living Garden","Poured","Brie","-","7.47%","Strawberry Hotcakes",683
+"Living Garden","Poured","Brie","-","6.73%","Camoflower",683

--- a/data/pop-csv/mousoleum.csv
+++ b/data/pop-csv/mousoleum.csv
@@ -1,35 +1,35 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Mousoleum","No Wall","Radioactive Blue","-","39.59%","Gluttonous Zombie",3837
-"Mousoleum","No Wall","Radioactive Blue","-","29.53%","Zombie",3837
-"Mousoleum","No Wall","Radioactive Blue","-","24.94%","Ravenous Zombie",3837
-"Mousoleum","No Wall","Radioactive Blue","-","5.94%","Coffin Zombie",3837
+"Mousoleum","No Wall","Radioactive Blue","-","40.30%","Gluttonous Zombie",5978
+"Mousoleum","No Wall","Radioactive Blue","-","28.99%","Zombie",5978
+"Mousoleum","No Wall","Radioactive Blue","-","24.91%","Ravenous Zombie",5978
+"Mousoleum","No Wall","Radioactive Blue","-","5.80%","Coffin Zombie",5978
 "Mousoleum","No Wall","Undead Emmental","-","28.09%","Coffin Zombie",559
 "Mousoleum","No Wall","Undead Emmental","-","20.93%","Gluttonous Zombie",559
 "Mousoleum","No Wall","Undead Emmental","-","18.43%","Zombie",559
 "Mousoleum","No Wall","Undead Emmental","-","12.34%","Ravenous Zombie",559
 "Mousoleum","No Wall","Undead Emmental","-","11.99%","Grave Robber",559
 "Mousoleum","No Wall","Undead Emmental","-","8.23%","Zombot Unipire",559
-"Mousoleum","No Wall","Crimson","-","97.23%","Coffin Zombie",469
-"Mousoleum","No Wall","Crimson","-","2.77%","Gluttonous Zombie",469
-"Mousoleum","Has Wall","Crimson","-","54.70%","Mousevina von Vermin",1373
-"Mousoleum","Has Wall","Crimson","-","15.66%","Vampire",1373
-"Mousoleum","Has Wall","Crimson","-","10.27%","Ghost",1373
-"Mousoleum","Has Wall","Crimson","-","10.20%","Bat",1373
-"Mousoleum","Has Wall","Crimson","-","9.18%","Mummy",1373
-"Mousoleum","Has Wall","Moon","-","56.19%","Lycan",105
-"Mousoleum","Has Wall","Moon","-","17.14%","Mummy",105
-"Mousoleum","Has Wall","Moon","-","11.43%","Bat",105
-"Mousoleum","Has Wall","Moon","-","9.52%","Ghost",105
-"Mousoleum","Has Wall","Moon","-","5.71%","Vampire",105
-"Mousoleum","Has Wall","Radioactive Blue","-","34.02%","Bat",2916
-"Mousoleum","Has Wall","Radioactive Blue","-","20.61%","Mummy",2916
-"Mousoleum","Has Wall","Radioactive Blue","-","20.10%","Vampire",2916
-"Mousoleum","Has Wall","Radioactive Blue","-","16.08%","Ghost",2916
-"Mousoleum","Has Wall","Radioactive Blue","-","5.97%","Giant Snail",2916
-"Mousoleum","Has Wall","Radioactive Blue","-","2.30%","Monster",2916
-"Mousoleum","Has Wall","Radioactive Blue","-","0.93%","Black Widow",2916
-"Mousoleum","Has Wall","Undead Emmental","-","33.62%","Mummy",229
-"Mousoleum","Has Wall","Undead Emmental","-","27.95%","Ghost",229
-"Mousoleum","Has Wall","Undead Emmental","-","16.16%","Grave Robber",229
-"Mousoleum","Has Wall","Undead Emmental","-","13.54%","Vampire",229
-"Mousoleum","Has Wall","Undead Emmental","-","8.73%","Zombot Unipire",229
+"Mousoleum","No Wall","Crimson","-","97.77%","Coffin Zombie",852
+"Mousoleum","No Wall","Crimson","-","2.23%","Gluttonous Zombie",852
+"Mousoleum","Has Wall","Crimson","-","55.14%","Mousevina von Vermin",2833
+"Mousoleum","Has Wall","Crimson","-","15.43%","Vampire",2833
+"Mousoleum","Has Wall","Crimson","-","10.45%","Ghost",2833
+"Mousoleum","Has Wall","Crimson","-","9.81%","Mummy",2833
+"Mousoleum","Has Wall","Crimson","-","9.18%","Bat",2833
+"Mousoleum","Has Wall","Moon","-","59.04%","Lycan",271
+"Mousoleum","Has Wall","Moon","-","12.92%","Bat",271
+"Mousoleum","Has Wall","Moon","-","10.33%","Mummy",271
+"Mousoleum","Has Wall","Moon","-","9.23%","Ghost",271
+"Mousoleum","Has Wall","Moon","-","8.49%","Vampire",271
+"Mousoleum","Has Wall","Radioactive Blue","-","34.85%","Bat",5265
+"Mousoleum","Has Wall","Radioactive Blue","-","20.28%","Vampire",5265
+"Mousoleum","Has Wall","Radioactive Blue","-","20.21%","Mummy",5265
+"Mousoleum","Has Wall","Radioactive Blue","-","16.14%","Ghost",5265
+"Mousoleum","Has Wall","Radioactive Blue","-","5.51%","Giant Snail",5265
+"Mousoleum","Has Wall","Radioactive Blue","-","2.07%","Monster",5265
+"Mousoleum","Has Wall","Radioactive Blue","-","0.93%","Black Widow",5265
+"Mousoleum","Has Wall","Undead Emmental","-","26.71%","Grave Robber",483
+"Mousoleum","Has Wall","Undead Emmental","-","23.40%","Mummy",483
+"Mousoleum","Has Wall","Undead Emmental","-","20.29%","Ghost",483
+"Mousoleum","Has Wall","Undead Emmental","-","17.18%","Zombot Unipire",483
+"Mousoleum","Has Wall","Undead Emmental","-","12.42%","Vampire",483

--- a/data/pop-csv/moussu-picchu.csv
+++ b/data/pop-csv/moussu-picchu.csv
@@ -1,44 +1,44 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Moussu Picchu","-","Glowing Gruyere","-","29.69%","Rainwater Purifier",36887
-"Moussu Picchu","-","Glowing Gruyere","-","28.08%","Breeze Borrower",36887
-"Moussu Picchu","-","Glowing Gruyere","-","16.32%","Cloud Collector",36887
-"Moussu Picchu","-","Glowing Gruyere","-","16.13%","Windy Farmer",36887
-"Moussu Picchu","-","Glowing Gruyere","-","9.79%","Homeopathic Apothecary",36887
-"Moussu Picchu","-","SB+","-","23.74%","Windy Farmer",5675
-"Moussu Picchu","-","SB+","-","23.19%","Cloud Collector",5675
-"Moussu Picchu","-","SB+","-","18.13%","Breeze Borrower",5675
-"Moussu Picchu","-","SB+","-","17.07%","Rainwater Purifier",5675
-"Moussu Picchu","-","SB+","-","8.39%","Nightshade Maiden",5675
-"Moussu Picchu","-","SB+","-","6.85%","Nightshade Flower Girl",5675
-"Moussu Picchu","-","SB+","-","2.63%","Spore Salesman",5675
-"Moussu Picchu","-","Gouda","-","22.10%","Windy Farmer",33346
-"Moussu Picchu","-","Gouda","-","21.80%","Cloud Collector",33346
-"Moussu Picchu","-","Gouda","-","15.66%","Spore Salesman",33346
-"Moussu Picchu","-","Gouda","-","14.86%","Nightshade Flower Girl",33346
-"Moussu Picchu","-","Gouda","-","12.94%","Breeze Borrower",33346
-"Moussu Picchu","-","Gouda","-","12.64%","Rainwater Purifier",33346
-"Moussu Picchu","-","Brie","-","22.69%","Cloud Collector",1203
-"Moussu Picchu","-","Brie","-","20.37%","Windy Farmer",1203
-"Moussu Picchu","-","Brie","-","15.38%","Nightshade Flower Girl",1203
-"Moussu Picchu","-","Brie","-","15.05%","Spore Salesman",1203
-"Moussu Picchu","-","Brie","-","13.80%","Rainwater Purifier",1203
-"Moussu Picchu","-","Brie","-","12.72%","Breeze Borrower",1203
-"Moussu Picchu","Rain low","Rainy","-","59.66%","Rain Wallower",4452
-"Moussu Picchu","Rain low","Rainy","-","40.34%","Rain Collector",4452
-"Moussu Picchu","Rain medium","Rainy","-","57.22%","Rain Summoner",8645
-"Moussu Picchu","Rain medium","Rainy","-","42.78%","Monsoon Maker",8645
-"Moussu Picchu","Rain high","Rainy","-","56.77%","Monsoon Maker",25267
-"Moussu Picchu","Rain high","Rainy","-","43.23%","Rainmancer",25267
-"Moussu Picchu","Rain max","Rainy","-","100.00%","Rainmancer",13922
-"Moussu Picchu","Wind low","Windy","-","59.56%","Wind Watcher",4513
-"Moussu Picchu","Wind low","Windy","-","40.44%","Charming Chimer",4513
-"Moussu Picchu","Wind medium","Windy","-","56.72%","Fluttering Flutist",8651
-"Moussu Picchu","Wind medium","Windy","-","43.28%","Cycloness",8651
-"Moussu Picchu","Wind high","Windy","-","57.89%","Cycloness",27045
-"Moussu Picchu","Wind high","Windy","-","42.11%","Wind Warrior",27045
-"Moussu Picchu","Wind max","Windy","-","100.00%","Wind Warrior",13361
-"Moussu Picchu","Storm low","Dragonvine","-","60.53%","Thunder Strike",1710
-"Moussu Picchu","Storm low","Dragonvine","-","39.47%","Violet Stormchild",1710
+"Moussu Picchu","-","Glowing Gruyere","-","29.76%","Rainwater Purifier",42957
+"Moussu Picchu","-","Glowing Gruyere","-","28.29%","Breeze Borrower",42957
+"Moussu Picchu","-","Glowing Gruyere","-","16.11%","Cloud Collector",42957
+"Moussu Picchu","-","Glowing Gruyere","-","16.08%","Windy Farmer",42957
+"Moussu Picchu","-","Glowing Gruyere","-","9.75%","Homeopathic Apothecary",42957
+"Moussu Picchu","-","SB+","-","23.83%","Windy Farmer",6949
+"Moussu Picchu","-","SB+","-","23.76%","Cloud Collector",6949
+"Moussu Picchu","-","SB+","-","17.53%","Breeze Borrower",6949
+"Moussu Picchu","-","SB+","-","17.23%","Rainwater Purifier",6949
+"Moussu Picchu","-","SB+","-","8.38%","Nightshade Maiden",6949
+"Moussu Picchu","-","SB+","-","6.61%","Nightshade Flower Girl",6949
+"Moussu Picchu","-","SB+","-","2.68%","Spore Salesman",6949
+"Moussu Picchu","-","Gouda","-","22.05%","Windy Farmer",42006
+"Moussu Picchu","-","Gouda","-","21.86%","Cloud Collector",42006
+"Moussu Picchu","-","Gouda","-","15.56%","Spore Salesman",42006
+"Moussu Picchu","-","Gouda","-","14.96%","Nightshade Flower Girl",42006
+"Moussu Picchu","-","Gouda","-","12.89%","Breeze Borrower",42006
+"Moussu Picchu","-","Gouda","-","12.67%","Rainwater Purifier",42006
+"Moussu Picchu","-","Brie","-","22.74%","Cloud Collector",1218
+"Moussu Picchu","-","Brie","-","20.53%","Windy Farmer",1218
+"Moussu Picchu","-","Brie","-","15.19%","Nightshade Flower Girl",1218
+"Moussu Picchu","-","Brie","-","15.02%","Spore Salesman",1218
+"Moussu Picchu","-","Brie","-","13.88%","Rainwater Purifier",1218
+"Moussu Picchu","-","Brie","-","12.64%","Breeze Borrower",1218
+"Moussu Picchu","Rain low","Rainy","-","59.39%","Rain Wallower",5612
+"Moussu Picchu","Rain low","Rainy","-","40.61%","Rain Collector",5612
+"Moussu Picchu","Rain medium","Rainy","-","57.08%","Rain Summoner",10941
+"Moussu Picchu","Rain medium","Rainy","-","42.92%","Monsoon Maker",10941
+"Moussu Picchu","Rain high","Rainy","-","56.72%","Monsoon Maker",33815
+"Moussu Picchu","Rain high","Rainy","-","43.28%","Rainmancer",33815
+"Moussu Picchu","Rain max","Rainy","-","100.00%","Rainmancer",18868
+"Moussu Picchu","Wind low","Windy","-","59.50%","Wind Watcher",5758
+"Moussu Picchu","Wind low","Windy","-","40.50%","Charming Chimer",5758
+"Moussu Picchu","Wind medium","Windy","-","57.25%","Fluttering Flutist",11280
+"Moussu Picchu","Wind medium","Windy","-","42.75%","Cycloness",11280
+"Moussu Picchu","Wind high","Windy","-","57.39%","Cycloness",37371
+"Moussu Picchu","Wind high","Windy","-","42.61%","Wind Warrior",37371
+"Moussu Picchu","Wind max","Windy","-","100.00%","Wind Warrior",18894
+"Moussu Picchu","Storm low","Dragonvine","-","60.76%","Thunder Strike",2431
+"Moussu Picchu","Storm low","Dragonvine","-","39.24%","Violet Stormchild",2431
 "Moussu Picchu","Storm medium","Dragonvine","-","58.00%","Thunderlord",
 "Moussu Picchu","Storm medium","Dragonvine","-","42.00%","Thundering Watcher",
 "Moussu Picchu","Storm high","Dragonvine","-","60.00%","Thundering Watcher",

--- a/data/pop-csv/prickly-plains.csv
+++ b/data/pop-csv/prickly-plains.csv
@@ -1,10 +1,10 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Prickly Plains","-","Bland Queso","-","60.63%","Spice Seer",57761
-"Prickly Plains","-","Bland Queso","-","39.37%","Old Spice Collector",57761
-"Prickly Plains","-","Mild Queso","-","50.47%","Spice Farmer",56782
-"Prickly Plains","-","Mild Queso","-","49.53%","Granny Spice",56782
-"Prickly Plains","-","Medium Queso","-","56.30%","Spice Finder",48896
-"Prickly Plains","-","Medium Queso","-","43.70%","Spice Sovereign",48896
-"Prickly Plains","-","Hot Queso","-","58.69%","Spice Reaper",29485
-"Prickly Plains","-","Hot Queso","-","41.31%","Spice Raider",29485
-"Prickly Plains","-","Flamin' Queso","-","100.00%","Inferna, The Engulfed",12644
+"Prickly Plains","-","Bland Queso","-","60.60%","Spice Seer",75973
+"Prickly Plains","-","Bland Queso","-","39.40%","Old Spice Collector",75973
+"Prickly Plains","-","Mild Queso","-","50.57%","Spice Farmer",74728
+"Prickly Plains","-","Mild Queso","-","49.43%","Granny Spice",74728
+"Prickly Plains","-","Medium Queso","-","56.33%","Spice Finder",65400
+"Prickly Plains","-","Medium Queso","-","43.67%","Spice Sovereign",65400
+"Prickly Plains","-","Hot Queso","-","58.89%","Spice Reaper",42110
+"Prickly Plains","-","Hot Queso","-","41.11%","Spice Raider",42110
+"Prickly Plains","-","Flamin' Queso","-","100.00%","Inferna, The Engulfed",18100

--- a/data/pop-csv/queso-river.csv
+++ b/data/pop-csv/queso-river.csv
@@ -1,15 +1,15 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Queso River","-","Gouda","-","34.68%","Pump Raider",144171
-"Queso River","-","Gouda","-","30.71%","Tiny Saboteur",144171
-"Queso River","-","Gouda","-","29.66%","Queso Extractor",144171
-"Queso River","-","Gouda","-","4.95%","Croquet Crusher",144171
-"Queso River","-","Brie","-","35.03%","Pump Raider",12260
-"Queso River","-","Brie","-","30.70%","Tiny Saboteur",12260
-"Queso River","-","Brie","-","29.47%","Queso Extractor",12260
-"Queso River","-","Brie","-","4.80%","Croquet Crusher",12260
-"Queso River","-","SB+","-","31.10%","Tiny Saboteur",37958
-"Queso River","-","SB+","-","29.08%","Pump Raider",37958
-"Queso River","-","SB+","-","24.48%","Sleepy Merchant",37958
-"Queso River","-","SB+","-","9.62%","Queso Extractor",37958
-"Queso River","-","SB+","-","5.72%","Croquet Crusher",37958
-"Queso River","-","Wildfire Queso","-","100.00%","Queen Quesada",5225
+"Queso River","-","Gouda","-","34.67%","Pump Raider",188144
+"Queso River","-","Gouda","-","30.70%","Tiny Saboteur",188144
+"Queso River","-","Gouda","-","29.68%","Queso Extractor",188144
+"Queso River","-","Gouda","-","4.95%","Croquet Crusher",188144
+"Queso River","-","Brie","-","34.85%","Pump Raider",14154
+"Queso River","-","Brie","-","30.70%","Tiny Saboteur",14154
+"Queso River","-","Brie","-","29.65%","Queso Extractor",14154
+"Queso River","-","Brie","-","4.80%","Croquet Crusher",14154
+"Queso River","-","SB+","-","30.82%","Tiny Saboteur",54247
+"Queso River","-","SB+","-","28.95%","Pump Raider",54247
+"Queso River","-","SB+","-","24.70%","Sleepy Merchant",54247
+"Queso River","-","SB+","-","9.64%","Queso Extractor",54247
+"Queso River","-","SB+","-","5.89%","Croquet Crusher",54247
+"Queso River","-","Wildfire Queso","-","100.00%","Queen Quesada",13054

--- a/data/pop-csv/toxic-spill.csv
+++ b/data/pop-csv/toxic-spill.csv
@@ -1,577 +1,582 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Toxic Spill","Hero","Rancid Radioactive Blue","-","20.87%","Sludge",1830
-"Toxic Spill","Hero","Rancid Radioactive Blue","-","20.11%","Swamp Runner",1830
-"Toxic Spill","Hero","Rancid Radioactive Blue","-","19.73%","Mutated Siblings",1830
-"Toxic Spill","Hero","Rancid Radioactive Blue","-","17.16%","Spore",1830
-"Toxic Spill","Hero","Rancid Radioactive Blue","-","16.89%","Monster Tail",1830
-"Toxic Spill","Hero","Rancid Radioactive Blue","-","5.25%","Bog Beast",1830
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","11.99%","Monster Tail",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","9.36%","Scrap Metal Monster",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","9.36%","Gelatinous Octahedron",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","7.89%","Biohazard",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","7.60%","Sludge Soaker",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","7.31%","Spore",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","4.97%","Plague Hag",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","4.68%","Mutant Mongrel",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","4.68%","Bog Beast",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","4.39%","Telekinetic Mutant",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","4.09%","Mutant Ninja",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","3.51%","Tentacle",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","3.51%","Mutated Siblings",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","3.22%","Sludge",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","2.92%","Outbreak Assassin",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","2.92%","Toxic Warrior",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","2.92%","Slimefist",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","2.05%","Swamp Runner",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","1.46%","The Menace",342
-"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","1.17%","Sludge Swimmer",342
-"Toxic Spill","Knight","Rancid Radioactive Blue","-","29.51%","Monster Tail",1830
-"Toxic Spill","Knight","Rancid Radioactive Blue","-","29.13%","Spore",1830
-"Toxic Spill","Knight","Rancid Radioactive Blue","-","13.33%","Sludge",1830
-"Toxic Spill","Knight","Rancid Radioactive Blue","-","11.64%","Gelatinous Octahedron",1830
-"Toxic Spill","Knight","Rancid Radioactive Blue","-","6.39%","Bog Beast",1830
-"Toxic Spill","Knight","Rancid Radioactive Blue","-","5.19%","Mutated Siblings",1830
-"Toxic Spill","Knight","Rancid Radioactive Blue","-","4.81%","Swamp Runner",1830
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","14.93%","Gelatinous Octahedron",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","7.71%","Spore",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","6.97%","Plague Hag",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","6.97%","Sludge Soaker",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","5.97%","Scrap Metal Monster",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","5.47%","Biohazard",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","5.47%","Telekinetic Mutant",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.98%","Slimefist",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.73%","Outbreak Assassin",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.73%","Toxic Warrior",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.73%","Monster Tail",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.48%","Mutant Ninja",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.48%","Mutant Mongrel",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","3.98%","Tentacle",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","3.48%","Sludge Swimmer",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","3.23%","The Menace",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","2.49%","Sludge",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","2.24%","Mutated Siblings",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","1.74%","Bog Beast",402
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","1.24%","Swamp Runner",402
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","19.74%","Sludge",2467
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","16.98%","Gelatinous Octahedron",2467
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","14.19%","Spore",2467
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","12.53%","Monster Tail",2467
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","10.74%","Sludge Soaker",2467
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","10.58%","Plague Hag",2467
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","6.45%","Scrap Metal Monster",2467
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","3.81%","Bog Beast",2467
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","2.72%","Swamp Runner",2467
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","2.27%","Mutated Siblings",2467
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","14.52%","Sludge Soaker",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","11.45%","Plague Hag",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","8.79%","Biohazard",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","7.57%","Toxic Warrior",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","6.75%","Telekinetic Mutant",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","6.54%","Scrap Metal Monster",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.73%","Tentacle",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.52%","Mutant Mongrel",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.52%","Sludge Swimmer",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.32%","Slimefist",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.32%","Mutant Ninja",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","4.50%","The Menace",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","4.29%","Outbreak Assassin",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","2.45%","Sludge",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","1.43%","Mutated Siblings",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","1.23%","Swamp Runner",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","1.02%","Gelatinous Octahedron",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","0.82%","Monster Tail",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","0.82%","Bog Beast",489
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","0.41%","Spore",489
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","27.44%","Plague Hag",2843
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","24.87%","Sludge Soaker",2843
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","21.14%","Gelatinous Octahedron",2843
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","6.19%","Scrap Metal Monster",2843
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","6.16%","Monster Tail",2843
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","4.19%","Spore",2843
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","3.76%","Bog Beast",2843
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","3.66%","Mutated Siblings",2843
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","1.34%","Sludge",2843
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","1.27%","Swamp Runner",2843
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","16.81%","Plague Hag",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","9.36%","Toxic Warrior",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","7.45%","Outbreak Assassin",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","7.23%","Slimefist",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","7.02%","Biohazard",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","6.38%","Sludge Swimmer",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","6.38%","Sludge Soaker",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","6.38%","Mutant Ninja",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","5.53%","Mutant Mongrel",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","5.53%","Scrap Metal Monster",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","5.32%","The Menace",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","4.68%","Telekinetic Mutant",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","4.68%","Tentacle",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","1.91%","Monster Tail",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","1.06%","Spore",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","1.06%","Bog Beast",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","0.85%","Gelatinous Octahedron",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","0.85%","Sludge",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","0.85%","Swamp Runner",470
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","0.64%","Mutated Siblings",470
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","15.24%","Plague Hag",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","14.00%","Sludge Soaker",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","13.85%","Biohazard",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","12.45%","Telekinetic Mutant",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","12.23%","Tentacle",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","8.39%","Mutant Ninja",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","7.59%","Gelatinous Octahedron",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","6.70%","Scrap Metal Monster",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","2.52%","Bog Beast",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","2.03%","Monster Tail",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","1.64%","Mutated Siblings",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","1.32%","Swamp Runner",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","1.10%","Spore",4087
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","0.93%","Sludge",4087
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","15.92%","Tentacle",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","14.57%","Telekinetic Mutant",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","11.88%","The Menace",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","9.64%","Biohazard",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","7.17%","Mutant Ninja",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","6.73%","Toxic Warrior",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","6.50%","Outbreak Assassin",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","6.05%","Slimefist",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","6.05%","Mutant Mongrel",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","5.16%","Sludge Swimmer",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.57%","Swamp Runner",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.35%","Gelatinous Octahedron",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.35%","Sludge Soaker",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.35%","Scrap Metal Monster",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.12%","Sludge",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.12%","Monster Tail",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","0.90%","Mutated Siblings",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","0.67%","Bog Beast",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","0.67%","Plague Hag",446
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","0.22%","Spore",446
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","17.06%","Toxic Warrior",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","13.62%","Slimefist",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","13.46%","Mutant Mongrel",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","13.18%","Outbreak Assassin",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","9.56%","Telekinetic Mutant",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","6.63%","Plague Hag",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","6.12%","Biohazard",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","5.51%","Tentacle",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","2.14%","Sludge Soaker",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","2.12%","Gelatinous Octahedron",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.96%","Mutant Ninja",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.91%","Scrap Metal Monster",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.40%","Bog Beast",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.27%","Mutated Siblings",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.07%","Spore",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.05%","Sludge",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","0.99%","Swamp Runner",3922
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","0.94%","Monster Tail",3922
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","17.04%","Slimefist",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","15.80%","Mutant Mongrel",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","15.31%","Sludge Swimmer",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","13.09%","Outbreak Assassin",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","11.36%","The Menace",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","9.63%","Toxic Warrior",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","2.47%","Sludge",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","2.22%","Biohazard",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.98%","Plague Hag",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.48%","Spore",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.48%","Telekinetic Mutant",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.23%","Tentacle",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.99%","Sludge Soaker",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.99%","Mutant Ninja",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.99%","Scrap Metal Monster",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.99%","Mutated Siblings",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.99%","Swamp Runner",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.74%","Bog Beast",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.49%","Monster Tail",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.49%","Glitchpaw",405
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.25%","Gelatinous Octahedron",405
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","10.76%","Mutant Mongrel",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","9.48%","Slimefist",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","9.20%","Outbreak Assassin",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","9.20%","Toxic Warrior",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","8.80%","Mutant Ninja",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","8.63%","Sludge Swimmer",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","8.43%","Telekinetic Mutant",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","8.33%","The Menace",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","6.60%","Sludge Soaker",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","5.56%","Biohazard",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","5.53%","Plague Hag",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","5.21%","Tentacle",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","4.27%","Scrap Metal Monster",5968
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","18.60%","The Menace",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","15.42%","Sludge Swimmer",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","15.17%","Slimefist",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","14.27%","Mutant Mongrel",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","14.27%","Outbreak Assassin",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","13.62%","Toxic Warrior",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.55%","Plague Hag",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.47%","Tentacle",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.39%","Telekinetic Mutant",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.22%","Biohazard",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.22%","Sludge Soaker",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","0.90%","Scrap Metal Monster",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","0.82%","Mutant Ninja",1226
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","0.08%","Glitchpaw",1226
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","13.18%","Mutant Mongrel",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","11.04%","Slimefist",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","10.64%","Mutated Behemoth",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","10.31%","Outbreak Assassin",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","10.17%","Telekinetic Mutant",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","9.96%","The Menace",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","8.43%","Toxic Warrior",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","7.91%","Sludge Swimmer",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","5.74%","Biohazard",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","5.37%","Tentacle",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","3.08%","Mutant Ninja",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","1.98%","Scrap Metal Monster",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","1.15%","Plague Hag",4249
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","1.06%","Sludge Soaker",4249
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","22.18%","Mutated Behemoth",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","15.61%","Sludge Swimmer",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","14.43%","The Menace",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","11.12%","Toxic Warrior",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","10.69%","Outbreak Assassin",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","10.53%","Slimefist",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","7.96%","Mutant Mongrel",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.23%","Plague Hag",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.18%","Tentacle",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.07%","Biohazard",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.02%","Mutant Ninja",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.02%","Telekinetic Mutant",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.02%","Sludge Soaker",1871
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","0.96%","Scrap Metal Monster",1871
-"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","19.63%","Mutated Siblings",535
-"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","18.88%","Swamp Runner",535
-"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","16.07%","Lab Technician",535
-"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","14.77%","Monster Tail",535
-"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","14.77%","Sludge",535
-"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","12.90%","Spore",535
-"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","2.99%","Bog Beast",535
-"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","25.25%","Spore",705
-"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","25.11%","Monster Tail",705
-"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","17.02%","Lab Technician",705
-"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","11.49%","Gelatinous Octahedron",705
-"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","9.79%","Sludge",705
-"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","3.97%","Swamp Runner",705
-"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","3.69%","Mutated Siblings",705
-"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","3.69%","Bog Beast",705
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","16.06%","Lab Technician",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","15.47%","Sludge",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","15.35%","Gelatinous Octahedron",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","12.16%","Spore",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","10.98%","Monster Tail",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","9.68%","Plague Hag",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","9.21%","Sludge Soaker",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","4.25%","Scrap Metal Monster",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","3.90%","Bog Beast",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","1.89%","Swamp Runner",847
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","1.06%","Mutated Siblings",847
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","23.89%","Sludge Soaker",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","21.73%","Plague Hag",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","17.50%","Gelatinous Octahedron",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","14.55%","Lab Technician",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","6.29%","Scrap Metal Monster",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","4.23%","Monster Tail",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","3.93%","Spore",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","2.75%","Mutated Siblings",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","2.75%","Bog Beast",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","1.47%","Swamp Runner",1017
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","0.88%","Sludge",1017
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","15.95%","Lab Technician",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","13.68%","Sludge Soaker",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","11.92%","Biohazard",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","11.27%","Plague Hag",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","10.10%","Telekinetic Mutant",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","9.14%","Tentacle",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","7.17%","Mutant Ninja",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","6.80%","Gelatinous Octahedron",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","5.93%","Scrap Metal Monster",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","2.27%","Bog Beast",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","2.12%","Monster Tail",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","1.10%","Sludge",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","1.02%","Swamp Runner",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","0.80%","Spore",1367
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","0.73%","Mutated Siblings",1367
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","13.41%","Lab Technician",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","13.01%","Toxic Warrior",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","12.04%","Outbreak Assassin",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","11.64%","Mutant Mongrel",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","11.06%","Slimefist",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","9.49%","Telekinetic Mutant",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","5.48%","Biohazard",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","5.38%","Tentacle",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","5.09%","Plague Hag",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","2.35%","Sludge Soaker",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.76%","Mutant Ninja",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.66%","Gelatinous Octahedron",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.57%","Scrap Metal Monster",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.27%","Sludge",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.27%","Mutated Siblings",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.27%","Bog Beast",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","0.88%","Swamp Runner",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","0.78%","Spore",1022
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","0.59%","Monster Tail",1022
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","12.25%","Lab Technician",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","9.19%","The Menace",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","8.56%","Sludge Swimmer",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","8.38%","Mutant Ninja",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","8.38%","Mutant Mongrel",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","8.29%","Toxic Warrior",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","7.39%","Sludge Soaker",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","7.39%","Slimefist",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","7.21%","Telekinetic Mutant",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","5.86%","Outbreak Assassin",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","4.86%","Plague Hag",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","4.59%","Biohazard",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","4.23%","Tentacle",1110
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","3.42%","Scrap Metal Monster",1110
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","11.70%","Mutated Behemoth",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","11.14%","Slimefist",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","10.86%","Mutant Mongrel",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","9.19%","Lab Technician",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","9.19%","The Menace",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","8.91%","Outbreak Assassin",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","8.36%","Toxic Warrior",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","7.52%","Sludge Swimmer",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","6.41%","Telekinetic Mutant",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","5.85%","Biohazard",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","3.62%","Tentacle",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","2.79%","Mutant Ninja",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","1.67%","Sludge Soaker",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","1.67%","Scrap Metal Monster",359
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","1.11%","Plague Hag",359
-"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","17.71%","Sludge",802
-"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","17.08%","Mutated Siblings",802
-"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","16.58%","Swamp Runner",802
-"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","16.33%","Hazmat",802
-"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","11.47%","Spore",802
-"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","11.22%","Monster Tail",802
-"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","5.99%","Lab Technician",802
-"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","3.62%","Bog Beast",802
-"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","25.09%","Spore",881
-"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","22.93%","Monster Tail",881
-"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","12.15%","Sludge",881
-"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","11.01%","Hazmat",881
-"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","10.10%","Gelatinous Octahedron",881
-"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","5.79%","Lab Technician",881
-"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","5.11%","Bog Beast",881
-"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","4.54%","Swamp Runner",881
-"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","3.29%","Mutated Siblings",881
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","14.29%","Hazmat",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","9.32%","Gelatinous Octahedron",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","8.70%","Scrap Metal Monster",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","6.83%","Lab Technician",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","6.21%","Spore",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","5.59%","Sludge Soaker",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","5.59%","Tentacle",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","5.59%","Slimefist",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","5.59%","Biohazard",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","4.97%","Telekinetic Mutant",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.73%","Plague Hag",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.11%","Mutant Mongrel",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.11%","Monster Tail",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.11%","Sludge Swimmer",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.11%","Mutant Ninja",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","2.48%","Toxic Warrior",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.86%","Sludge",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.86%","Swamp Runner",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.86%","Outbreak Assassin",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.24%","Bog Beast",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.24%","The Menace",161
-"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","0.62%","Mutated Siblings",161
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","15.67%","Sludge",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","14.00%","Hazmat",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","13.33%","Spore",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","12.57%","Gelatinous Octahedron",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","9.64%","Monster Tail",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","8.30%","Sludge Soaker",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","8.30%","Plague Hag",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","6.54%","Lab Technician",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","5.78%","Scrap Metal Monster",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","2.43%","Bog Beast",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","1.76%","Swamp Runner",1193
-"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","1.68%","Mutated Siblings",1193
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","18.33%","Hazmat",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","10.83%","Sludge Soaker",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","8.33%","Biohazard",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","6.67%","Sludge Swimmer",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","6.67%","Mutant Ninja",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","6.67%","The Menace",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","5.83%","Plague Hag",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","5.83%","Lab Technician",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","5.00%","Slimefist",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","4.17%","Outbreak Assassin",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","3.33%","Scrap Metal Monster",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","3.33%","Mutant Mongrel",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","3.33%","Toxic Warrior",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","3.33%","Telekinetic Mutant",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","2.50%","Tentacle",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","1.67%","Monster Tail",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","1.67%","Mutated Siblings",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","0.83%","Sludge",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","0.83%","Swamp Runner",120
-"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","0.83%","Gelatinous Octahedron",120
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","22.16%","Plague Hag",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","22.08%","Sludge Soaker",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","15.46%","Gelatinous Octahedron",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","12.93%","Hazmat",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","6.23%","Lab Technician",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","4.97%","Monster Tail",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","4.89%","Scrap Metal Monster",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","3.00%","Spore",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","3.00%","Mutated Siblings",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","2.84%","Bog Beast",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","1.58%","Sludge",1268
-"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","0.87%","Swamp Runner",1268
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","18.35%","Hazmat",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","11.93%","Plague Hag",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","8.26%","Slimefist",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","7.34%","Outbreak Assassin",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","6.42%","Tentacle",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","6.42%","Sludge Soaker",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","5.50%","Lab Technician",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","5.50%","Biohazard",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","4.59%","Mutant Ninja",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","3.67%","Toxic Warrior",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","3.67%","The Menace",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","3.67%","Telekinetic Mutant",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","2.75%","Sludge Swimmer",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","2.75%","Scrap Metal Monster",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","1.83%","Bog Beast",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","1.83%","Mutant Mongrel",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.92%","Sludge",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.92%","Spore",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.92%","Monster Tail",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.92%","Gelatinous Octahedron",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.92%","Glitchpaw",109
-"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.92%","Swamp Runner",109
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","14.17%","Hazmat",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","12.28%","Sludge Soaker",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","11.84%","Plague Hag",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","10.90%","Biohazard",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","10.65%","Telekinetic Mutant",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","9.71%","Tentacle",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","6.74%","Mutant Ninja",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","5.60%","Lab Technician",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","5.25%","Gelatinous Octahedron",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","5.05%","Scrap Metal Monster",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","2.13%","Monster Tail",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","1.49%","Bog Beast",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","1.39%","Mutated Siblings",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","1.19%","Swamp Runner",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","0.84%","Spore",2019
-"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","0.79%","Sludge",2019
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","19.30%","Hazmat",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","12.28%","Telekinetic Mutant",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","10.53%","Biohazard",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","8.77%","The Menace",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","8.77%","Sludge Swimmer",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","8.77%","Tentacle",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","7.89%","Mutant Mongrel",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","6.14%","Mutant Ninja",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","3.51%","Slimefist",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","2.63%","Lab Technician",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","2.63%","Outbreak Assassin",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","1.75%","Monster Tail",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","1.75%","Toxic Warrior",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","1.75%","Mutated Siblings",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","0.88%","Bog Beast",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","0.88%","Plague Hag",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","0.88%","Scrap Metal Monster",114
-"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","0.88%","Spore",114
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","13.71%","Toxic Warrior",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","13.16%","Hazmat",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","13.11%","Slimefist",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","10.98%","Mutant Mongrel",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","10.48%","Outbreak Assassin",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","6.61%","Telekinetic Mutant",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","5.37%","Plague Hag",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","5.27%","Biohazard",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","4.87%","Tentacle",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","4.32%","Lab Technician",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","2.29%","Mutant Ninja",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","1.89%","Scrap Metal Monster",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","1.84%","Sludge Soaker",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","1.39%","Gelatinous Octahedron",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.99%","Swamp Runner",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.94%","Bog Beast",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.89%","Sludge",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.65%","Spore",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.65%","Monster Tail",2013
-"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.60%","Mutated Siblings",2013
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","14.38%","The Menace",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","14.38%","Mutant Mongrel",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","14.38%","Hazmat",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","11.11%","Slimefist",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","11.11%","Sludge Swimmer",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","7.84%","Outbreak Assassin",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","6.54%","Toxic Warrior",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","3.92%","Lab Technician",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","3.27%","Scrap Metal Monster",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.96%","Monster Tail",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.96%","Biohazard",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.96%","Swamp Runner",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.96%","Sludge",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.31%","Telekinetic Mutant",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.65%","Bog Beast",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.65%","Gelatinous Octahedron",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.65%","Sludge Soaker",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.65%","Mutant Ninja",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.65%","Plague Hag",153
-"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.65%","Spore",153
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","14.19%","Hazmat",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","8.23%","Mutant Mongrel",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","7.85%","Mutant Ninja",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","7.26%","Telekinetic Mutant",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","7.26%","Outbreak Assassin",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","7.15%","Toxic Warrior",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","7.04%","Slimefist",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","6.77%","Biohazard",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","6.55%","Sludge Swimmer",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","6.33%","The Menace",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","5.04%","Plague Hag",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","4.87%","Sludge Soaker",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","4.11%","Tentacle",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","3.68%","Lab Technician",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","3.68%","Scrap Metal Monster",1847
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","20.16%","The Menace",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","13.71%","Hazmat",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","12.90%","Sludge Swimmer",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","12.90%","Mutant Mongrel",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","11.29%","Toxic Warrior",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","11.29%","Outbreak Assassin",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","8.06%","Slimefist",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","3.23%","Biohazard",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","2.42%","Lab Technician",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.61%","Plague Hag",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.81%","Scrap Metal Monster",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.81%","Telekinetic Mutant",124
-"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.81%","Sludge Soaker",124
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","11.57%","Mutated Behemoth",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","11.28%","Hazmat",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","11.14%","Mutant Mongrel",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","9.87%","The Menace",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","8.32%","Telekinetic Mutant",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","8.04%","Slimefist",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","7.33%","Outbreak Assassin",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","7.05%","Sludge Swimmer",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","5.78%","Toxic Warrior",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","4.37%","Tentacle",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","4.09%","Mutant Ninja",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","4.09%","Biohazard",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","3.95%","Lab Technician",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","1.13%","Sludge Soaker",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","0.99%","Scrap Metal Monster",709
-"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","0.99%","Plague Hag",709
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","22.61%","Mutated Behemoth",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","16.52%","Sludge Swimmer",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","14.78%","The Menace",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","11.30%","Outbreak Assassin",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","8.70%","Slimefist",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","6.96%","Toxic Warrior",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","6.96%","Hazmat",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","6.09%","Mutant Mongrel",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","3.48%","Lab Technician",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","0.87%","Biohazard",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","0.87%","Mutant Ninja",115
-"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","0.87%","Plague Hag",115
+"Toxic Spill","Hero","Rancid Radioactive Blue","-","21.09%","Sludge",2200
+"Toxic Spill","Hero","Rancid Radioactive Blue","-","20.18%","Swamp Runner",2200
+"Toxic Spill","Hero","Rancid Radioactive Blue","-","20.18%","Mutated Siblings",2200
+"Toxic Spill","Hero","Rancid Radioactive Blue","-","16.82%","Spore",2200
+"Toxic Spill","Hero","Rancid Radioactive Blue","-","16.36%","Monster Tail",2200
+"Toxic Spill","Hero","Rancid Radioactive Blue","-","5.36%","Bog Beast",2200
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","10.94%","Monster Tail",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","9.44%","Gelatinous Octahedron",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","8.15%","Scrap Metal Monster",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","7.73%","Sludge Soaker",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","7.51%","Spore",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","7.08%","Biohazard",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","5.58%","Plague Hag",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","5.36%","Bog Beast",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","4.72%","Mutant Mongrel",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","4.51%","Mutant Ninja",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","4.08%","Telekinetic Mutant",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","4.08%","Tentacle",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","3.65%","Slimefist",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","3.22%","Mutated Siblings",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","3.00%","Swamp Runner",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","3.00%","Sludge",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","3.00%","Toxic Warrior",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","2.79%","Outbreak Assassin",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","1.07%","Sludge Swimmer",466
+"Toxic Spill","Hero","Magical Rancid Radioactive Blue","-","1.07%","The Menace",466
+"Toxic Spill","Knight","Rancid Radioactive Blue","-","29.53%","Spore",2252
+"Toxic Spill","Knight","Rancid Radioactive Blue","-","29.26%","Monster Tail",2252
+"Toxic Spill","Knight","Rancid Radioactive Blue","-","13.32%","Sludge",2252
+"Toxic Spill","Knight","Rancid Radioactive Blue","-","11.50%","Gelatinous Octahedron",2252
+"Toxic Spill","Knight","Rancid Radioactive Blue","-","6.57%","Bog Beast",2252
+"Toxic Spill","Knight","Rancid Radioactive Blue","-","5.06%","Mutated Siblings",2252
+"Toxic Spill","Knight","Rancid Radioactive Blue","-","4.75%","Swamp Runner",2252
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","14.73%","Gelatinous Octahedron",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","7.47%","Spore",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","7.47%","Plague Hag",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","6.22%","Sludge Soaker",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","6.02%","Scrap Metal Monster",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","5.81%","Biohazard",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","5.60%","Slimefist",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","5.19%","Telekinetic Mutant",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.98%","Mutant Ninja",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.77%","Outbreak Assassin",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.56%","Monster Tail",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","4.36%","Mutant Mongrel",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","3.94%","Tentacle",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","3.94%","Toxic Warrior",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","3.53%","The Menace",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","3.53%","Sludge Swimmer",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","2.90%","Sludge",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","2.07%","Mutated Siblings",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","1.45%","Bog Beast",482
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","-","1.45%","Swamp Runner",482
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","19.65%","Sludge",2820
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","17.02%","Gelatinous Octahedron",2820
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","14.29%","Spore",2820
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","12.52%","Monster Tail",2820
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","10.85%","Sludge Soaker",2820
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","10.57%","Plague Hag",2820
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","6.24%","Scrap Metal Monster",2820
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","3.83%","Bog Beast",2820
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","2.70%","Swamp Runner",2820
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","-","2.34%","Mutated Siblings",2820
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","14.71%","Sludge Soaker",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","12.29%","Plague Hag",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","8.14%","Biohazard",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","7.86%","Toxic Warrior",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","6.57%","Telekinetic Mutant",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","6.14%","Scrap Metal Monster",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","6.00%","Tentacle",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.57%","Slimefist",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.43%","Mutant Ninja",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.29%","Mutant Mongrel",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.14%","Outbreak Assassin",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","5.00%","Sludge Swimmer",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","4.00%","The Menace",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","2.14%","Sludge",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","1.71%","Mutated Siblings",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","1.14%","Gelatinous Octahedron",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","1.00%","Swamp Runner",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","0.86%","Monster Tail",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","0.57%","Bog Beast",700
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","-","0.43%","Spore",700
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","27.70%","Plague Hag",3303
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","24.74%","Sludge Soaker",3303
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","20.83%","Gelatinous Octahedron",3303
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","6.27%","Scrap Metal Monster",3303
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","6.15%","Monster Tail",3303
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","4.09%","Spore",3303
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","4.06%","Bog Beast",3303
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","3.51%","Mutated Siblings",3303
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","1.42%","Sludge",3303
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","-","1.24%","Swamp Runner",3303
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","17.23%","Plague Hag",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","9.18%","Toxic Warrior",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","7.12%","Outbreak Assassin",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","6.93%","Slimefist",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","6.74%","Biohazard",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","6.74%","Sludge Swimmer",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","6.55%","Sludge Soaker",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","5.99%","Mutant Ninja",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","5.62%","The Menace",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","5.62%","Mutant Mongrel",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","5.43%","Scrap Metal Monster",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","4.87%","Telekinetic Mutant",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","4.87%","Tentacle",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","1.69%","Monster Tail",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","1.12%","Bog Beast",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","0.94%","Spore",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","0.94%","Gelatinous Octahedron",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","0.94%","Sludge",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","0.94%","Swamp Runner",534
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","-","0.56%","Mutated Siblings",534
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","15.20%","Plague Hag",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","14.21%","Sludge Soaker",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","13.63%","Biohazard",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","12.31%","Tentacle",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","12.20%","Telekinetic Mutant",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","8.50%","Mutant Ninja",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","7.49%","Gelatinous Octahedron",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","6.72%","Scrap Metal Monster",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","2.59%","Bog Beast",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","2.09%","Monster Tail",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","1.55%","Mutated Siblings",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","1.34%","Swamp Runner",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","1.20%","Spore",5165
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","-","0.97%","Sludge",5165
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","15.28%","Tentacle",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","14.60%","Telekinetic Mutant",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","12.56%","The Menace",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","9.00%","Biohazard",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","7.30%","Mutant Ninja",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","6.62%","Sludge Swimmer",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","6.45%","Toxic Warrior",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","6.28%","Slimefist",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","5.94%","Outbreak Assassin",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","5.43%","Mutant Mongrel",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.53%","Swamp Runner",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.36%","Sludge",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.19%","Scrap Metal Monster",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.19%","Mutated Siblings",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.19%","Monster Tail",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.19%","Gelatinous Octahedron",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","1.02%","Sludge Soaker",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","0.68%","Spore",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","0.68%","Plague Hag",589
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","-","0.51%","Bog Beast",589
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","17.36%","Toxic Warrior",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","13.59%","Slimefist",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","13.26%","Mutant Mongrel",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","12.79%","Outbreak Assassin",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","9.79%","Telekinetic Mutant",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","6.70%","Plague Hag",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","6.37%","Biohazard",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","5.34%","Tentacle",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","2.15%","Gelatinous Octahedron",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","2.11%","Sludge Soaker",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","2.09%","Mutant Ninja",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.92%","Scrap Metal Monster",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.28%","Bog Beast",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.20%","Mutated Siblings",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.08%","Spore",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.03%","Sludge",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","1.01%","Monster Tail",4833
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","-","0.91%","Swamp Runner",4833
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","16.20%","Slimefist",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","15.78%","Mutant Mongrel",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","15.78%","Sludge Swimmer",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","12.79%","The Menace",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","12.15%","Outbreak Assassin",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","9.81%","Toxic Warrior",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","2.13%","Sludge",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","2.13%","Biohazard",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.92%","Plague Hag",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.71%","Telekinetic Mutant",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.28%","Spore",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.28%","Mutant Ninja",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.07%","Swamp Runner",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","1.07%","Tentacle",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.85%","Bog Beast",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.85%","Sludge Soaker",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.85%","Scrap Metal Monster",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.85%","Mutated Siblings",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.64%","Monster Tail",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.43%","Glitchpaw",469
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","-","0.43%","Gelatinous Octahedron",469
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","10.95%","Mutant Mongrel",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","9.39%","Slimefist",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","9.16%","Toxic Warrior",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","8.77%","Outbreak Assassin",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","8.75%","Mutant Ninja",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","8.67%","Telekinetic Mutant",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","8.60%","Sludge Swimmer",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","8.50%","The Menace",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","6.63%","Sludge Soaker",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","5.67%","Biohazard",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","5.56%","Plague Hag",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","5.24%","Tentacle",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","-","4.11%","Scrap Metal Monster",7105
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","18.34%","The Menace",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","15.88%","Sludge Swimmer",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","14.71%","Slimefist",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","14.39%","Mutant Mongrel",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","13.87%","Outbreak Assassin",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","13.61%","Toxic Warrior",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.49%","Tentacle",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.49%","Biohazard",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.43%","Plague Hag",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.36%","Sludge Soaker",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.23%","Telekinetic Mutant",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.10%","Mutant Ninja",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","1.04%","Scrap Metal Monster",1543
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","-","0.06%","Glitchpaw",1543
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","13.16%","Mutant Mongrel",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","11.21%","Slimefist",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","10.61%","Mutated Behemoth",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","10.00%","Telekinetic Mutant",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","9.96%","Outbreak Assassin",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","9.75%","The Menace",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","8.41%","Toxic Warrior",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","8.38%","Sludge Swimmer",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","5.79%","Biohazard",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","5.49%","Tentacle",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","2.96%","Mutant Ninja",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","2.10%","Scrap Metal Monster",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","1.14%","Plague Hag",5372
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","-","1.04%","Sludge Soaker",5372
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","21.92%","Mutated Behemoth",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","15.47%","Sludge Swimmer",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","14.95%","The Menace",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","10.92%","Outbreak Assassin",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","10.84%","Toxic Warrior",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","10.80%","Slimefist",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","8.14%","Mutant Mongrel",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.13%","Biohazard",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.05%","Scrap Metal Monster",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.01%","Plague Hag",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.01%","Tentacle",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","1.01%","Telekinetic Mutant",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","0.93%","Mutant Ninja",2482
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","-","0.85%","Sludge Soaker",2482
+"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","19.29%","Mutated Siblings",617
+"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","18.48%","Swamp Runner",617
+"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","15.40%","Lab Technician",617
+"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","15.07%","Monster Tail",617
+"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","15.07%","Sludge",617
+"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","13.45%","Spore",617
+"Toxic Spill","Hero","Rancid Radioactive Blue","Rotten","3.24%","Bog Beast",617
+"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","25.38%","Spore",796
+"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","25.13%","Monster Tail",796
+"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","17.34%","Lab Technician",796
+"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","10.68%","Gelatinous Octahedron",796
+"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","10.18%","Sludge",796
+"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","3.77%","Swamp Runner",796
+"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","3.77%","Mutated Siblings",796
+"Toxic Spill","Knight","Rancid Radioactive Blue","Rotten","3.77%","Bog Beast",796
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","16.26%","Lab Technician",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","15.85%","Gelatinous Octahedron",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","14.94%","Sludge",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","11.79%","Spore",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","11.18%","Monster Tail",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","9.45%","Plague Hag",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","9.45%","Sludge Soaker",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","4.27%","Scrap Metal Monster",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","3.66%","Bog Beast",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","1.93%","Swamp Runner",984
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Rotten","1.22%","Mutated Siblings",984
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","23.12%","Sludge Soaker",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","21.93%","Plague Hag",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","17.61%","Gelatinous Octahedron",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","14.59%","Lab Technician",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","6.15%","Scrap Metal Monster",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","4.50%","Monster Tail",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","3.76%","Spore",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","3.12%","Bog Beast",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","2.84%","Mutated Siblings",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","1.47%","Swamp Runner",1090
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Rotten","0.92%","Sludge",1090
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","15.61%","Lab Technician",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","13.80%","Sludge Soaker",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","11.91%","Biohazard",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","11.31%","Plague Hag",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","10.23%","Telekinetic Mutant",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","8.95%","Tentacle",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","7.27%","Mutant Ninja",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","6.59%","Gelatinous Octahedron",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","6.12%","Scrap Metal Monster",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","2.22%","Bog Beast",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","2.22%","Monster Tail",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","1.14%","Sludge",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","1.08%","Swamp Runner",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","0.87%","Spore",1486
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Rotten","0.67%","Mutated Siblings",1486
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","14.18%","Toxic Warrior",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","13.71%","Lab Technician",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","11.47%","Mutant Mongrel",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","11.47%","Outbreak Assassin",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","10.92%","Slimefist",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","9.32%","Telekinetic Mutant",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","5.66%","Tentacle",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","5.58%","Biohazard",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","5.02%","Plague Hag",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","2.23%","Sludge Soaker",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.59%","Mutant Ninja",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.51%","Gelatinous Octahedron",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.43%","Scrap Metal Monster",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.35%","Sludge",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.35%","Bog Beast",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","1.04%","Mutated Siblings",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","0.80%","Spore",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","0.80%","Swamp Runner",1255
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Rotten","0.56%","Monster Tail",1255
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","12.19%","Lab Technician",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","9.20%","Sludge Swimmer",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","9.12%","The Menace",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","8.29%","Mutant Mongrel",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","8.21%","Mutant Ninja",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","8.21%","Toxic Warrior",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","7.30%","Slimefist",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","7.21%","Sludge Soaker",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","6.97%","Telekinetic Mutant",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","6.14%","Outbreak Assassin",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","4.73%","Plague Hag",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","4.64%","Biohazard",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","4.39%","Tentacle",1206
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Rotten","3.40%","Scrap Metal Monster",1206
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","11.28%","Slimefist",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","11.28%","Mutant Mongrel",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","11.03%","Mutated Behemoth",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","9.52%","Outbreak Assassin",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","9.27%","Lab Technician",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","8.27%","Toxic Warrior",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","8.27%","The Menace",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","7.27%","Sludge Swimmer",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","6.52%","Telekinetic Mutant",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","6.27%","Biohazard",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","3.51%","Tentacle",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","2.76%","Mutant Ninja",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","1.75%","Scrap Metal Monster",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","1.50%","Sludge Soaker",399
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Rotten","1.50%","Plague Hag",399
+"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","17.24%","Sludge",1166
+"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","16.98%","Swamp Runner",1166
+"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","16.12%","Mutated Siblings",1166
+"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","15.52%","Hazmat",1166
+"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","12.18%","Monster Tail",1166
+"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","11.92%","Spore",1166
+"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","5.92%","Lab Technician",1166
+"Toxic Spill","Hero","Rancid Radioactive Blue","Super Rotten","4.12%","Bog Beast",1166
+"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","24.37%","Spore",1112
+"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","23.56%","Monster Tail",1112
+"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","11.96%","Sludge",1112
+"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","11.78%","Hazmat",1112
+"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","10.34%","Gelatinous Octahedron",1112
+"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","5.58%","Lab Technician",1112
+"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","4.86%","Bog Beast",1112
+"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","4.41%","Swamp Runner",1112
+"Toxic Spill","Knight","Rancid Radioactive Blue","Super Rotten","3.15%","Mutated Siblings",1112
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","13.86%","Hazmat",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","9.04%","Gelatinous Octahedron",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","8.43%","Scrap Metal Monster",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","6.63%","Lab Technician",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","6.02%","Biohazard",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","6.02%","Tentacle",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","6.02%","Slimefist",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","6.02%","Spore",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","5.42%","Sludge Soaker",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","4.82%","Telekinetic Mutant",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.61%","Plague Hag",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.61%","Monster Tail",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.61%","Mutant Ninja",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.01%","Mutant Mongrel",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","3.01%","Sludge Swimmer",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","2.41%","Toxic Warrior",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.81%","Sludge",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.81%","Swamp Runner",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.81%","Outbreak Assassin",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.20%","Bog Beast",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","1.20%","The Menace",166
+"Toxic Spill","Knight","Magical Rancid Radioactive Blue","Super Rotten","0.60%","Mutated Siblings",166
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","15.71%","Sludge",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","14.14%","Hazmat",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","13.16%","Spore",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","13.08%","Gelatinous Octahedron",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","9.32%","Monster Tail",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","8.72%","Plague Hag",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","8.57%","Sludge Soaker",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","6.24%","Lab Technician",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","5.34%","Scrap Metal Monster",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","2.56%","Bog Beast",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","1.65%","Swamp Runner",1330
+"Toxic Spill","Lord/Lady","Rancid Radioactive Blue","Super Rotten","1.50%","Mutated Siblings",1330
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","16.67%","Hazmat",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","10.49%","Sludge Soaker",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","9.26%","Biohazard",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","8.64%","Sludge Swimmer",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","5.56%","Outbreak Assassin",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","5.56%","Mutant Ninja",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","4.94%","Slimefist",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","4.94%","Plague Hag",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","4.94%","The Menace",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","4.94%","Lab Technician",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","4.32%","Mutant Mongrel",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","3.70%","Scrap Metal Monster",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","3.70%","Tentacle",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","3.70%","Toxic Warrior",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","3.09%","Telekinetic Mutant",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","1.23%","Monster Tail",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","1.23%","Mutated Siblings",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","1.23%","Gelatinous Octahedron",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","0.62%","Sludge",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","0.62%","Swamp Runner",162
+"Toxic Spill","Lord/Lady","Magical Rancid Radioactive Blue","Super Rotten","0.62%","Bog Beast",162
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","22.15%","Plague Hag",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","21.74%","Sludge Soaker",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","15.83%","Gelatinous Octahedron",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","13.47%","Hazmat",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","5.90%","Lab Technician",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","4.86%","Monster Tail",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","4.58%","Scrap Metal Monster",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","3.13%","Mutated Siblings",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","3.06%","Bog Beast",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","3.06%","Spore",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","1.46%","Sludge",1440
+"Toxic Spill","Baron/Baroness","Rancid Radioactive Blue","Super Rotten","0.76%","Swamp Runner",1440
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","17.09%","Hazmat",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","11.11%","Plague Hag",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","7.69%","Slimefist",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","7.69%","Sludge Soaker",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","6.84%","Outbreak Assassin",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","5.98%","Tentacle",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","5.13%","Lab Technician",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","5.13%","Biohazard",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","4.27%","The Menace",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","4.27%","Mutant Ninja",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","4.27%","Scrap Metal Monster",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","3.42%","Toxic Warrior",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","3.42%","Sludge Swimmer",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","3.42%","Telekinetic Mutant",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","1.71%","Mutant Mongrel",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","1.71%","Sludge",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","1.71%","Bog Beast",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.85%","Monster Tail",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.85%","Gelatinous Octahedron",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.85%","Glitchpaw",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.85%","Spore",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.85%","Swamp Runner",117
+"Toxic Spill","Baron/Baroness","Magical Rancid Radioactive Blue","Super Rotten","0.85%","Mutated Siblings",117
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","14.32%","Hazmat",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","12.42%","Sludge Soaker",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","12.16%","Plague Hag",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","10.96%","Biohazard",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","10.08%","Telekinetic Mutant",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","9.73%","Tentacle",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","6.59%","Mutant Ninja",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","5.53%","Gelatinous Octahedron",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","5.48%","Lab Technician",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","5.08%","Scrap Metal Monster",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","1.99%","Monster Tail",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","1.64%","Bog Beast",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","1.28%","Mutated Siblings",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","1.11%","Swamp Runner",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","0.84%","Spore",2262
+"Toxic Spill","Count/Countess","Rancid Radioactive Blue","Super Rotten","0.80%","Sludge",2262
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","18.12%","Hazmat",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","13.77%","Telekinetic Mutant",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","12.32%","Tentacle",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","8.70%","The Menace",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","8.70%","Biohazard",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","7.25%","Mutant Mongrel",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","7.25%","Sludge Swimmer",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","5.80%","Mutant Ninja",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","3.62%","Outbreak Assassin",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","3.62%","Slimefist",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","2.90%","Toxic Warrior",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","2.17%","Lab Technician",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","1.45%","Monster Tail",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","1.45%","Mutated Siblings",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","0.72%","Plague Hag",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","0.72%","Scrap Metal Monster",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","0.72%","Spore",138
+"Toxic Spill","Count/Countess","Magical Rancid Radioactive Blue","Super Rotten","0.72%","Bog Beast",138
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","13.75%","Hazmat",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","13.41%","Toxic Warrior",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","12.98%","Slimefist",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","10.84%","Mutant Mongrel",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","10.28%","Outbreak Assassin",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","6.86%","Telekinetic Mutant",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","5.36%","Biohazard",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","5.23%","Plague Hag",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","4.67%","Tentacle",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","4.33%","Lab Technician",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","2.23%","Mutant Ninja",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","1.97%","Scrap Metal Monster",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","1.97%","Sludge Soaker",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","1.46%","Gelatinous Octahedron",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.99%","Swamp Runner",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.94%","Bog Beast",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.77%","Sludge",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.73%","Mutated Siblings",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.69%","Monster Tail",2334
+"Toxic Spill","Duke/Duchess","Rancid Radioactive Blue","Super Rotten","0.56%","Spore",2334
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","14.98%","Mutant Mongrel",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","14.49%","Hazmat",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","13.53%","The Menace",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","11.59%","Sludge Swimmer",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","10.63%","Slimefist",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","7.73%","Outbreak Assassin",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","6.76%","Toxic Warrior",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","4.35%","Lab Technician",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","2.42%","Biohazard",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","2.42%","Scrap Metal Monster",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.93%","Sludge",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.45%","Gelatinous Octahedron",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.45%","Swamp Runner",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.45%","Monster Tail",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.97%","Telekinetic Mutant",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.97%","Spore",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.48%","Plague Hag",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.48%","Sludge Soaker",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.48%","Bog Beast",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.48%","Mutant Ninja",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.48%","Tentacle",207
+"Toxic Spill","Duke/Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.48%","Mutated Siblings",207
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","14.41%","Hazmat",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","8.16%","Mutant Mongrel",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","7.54%","Mutant Ninja",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","7.25%","Telekinetic Mutant",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","7.08%","Sludge Swimmer",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","7.04%","Outbreak Assassin",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","6.87%","The Menace",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","6.83%","Toxic Warrior",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","6.79%","Slimefist",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","6.58%","Biohazard",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","5.01%","Sludge Soaker",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","4.89%","Plague Hag",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","4.31%","Tentacle",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","3.64%","Scrap Metal Monster",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Rancid Radioactive Blue","Super Rotten","3.60%","Lab Technician",2415
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","18.39%","The Menace",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","13.03%","Sludge Swimmer",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","12.64%","Mutant Mongrel",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","11.88%","Slimefist",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","11.11%","Hazmat",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","11.11%","Toxic Warrior",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","9.96%","Outbreak Assassin",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","4.98%","Lab Technician",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","2.30%","Biohazard",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.53%","Tentacle",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.15%","Telekinetic Mutant",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","1.15%","Plague Hag",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.38%","Sludge Soaker",261
+"Toxic Spill","Grand Duke/Grand Duchess","Magical Rancid Radioactive Blue","Super Rotten","0.38%","Scrap Metal Monster",261
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","11.88%","Hazmat",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","11.15%","Mutant Mongrel",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","10.30%","Mutated Behemoth",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","9.46%","The Menace",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","8.94%","Slimefist",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","7.78%","Telekinetic Mutant",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","7.68%","Outbreak Assassin",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","7.15%","Sludge Swimmer",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","5.47%","Toxic Warrior",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","4.84%","Biohazard",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","4.52%","Tentacle",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","4.31%","Lab Technician",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","3.36%","Mutant Ninja",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","1.16%","Scrap Metal Monster",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","1.05%","Plague Hag",951
+"Toxic Spill","Archduke/Archduchess","Rancid Radioactive Blue","Super Rotten","0.95%","Sludge Soaker",951
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","19.65%","Mutated Behemoth",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","16.18%","Sludge Swimmer",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","15.03%","The Menace",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","13.87%","Hazmat",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","10.40%","Outbreak Assassin",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","6.94%","Toxic Warrior",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","6.94%","Slimefist",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","5.20%","Mutant Mongrel",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","3.47%","Lab Technician",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","1.16%","Plague Hag",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","0.58%","Mutant Ninja",173
+"Toxic Spill","Archduke/Archduchess","Magical Rancid Radioactive Blue","Super Rotten","0.58%","Biohazard",173

--- a/data/pop-js/forbidden-grove.js
+++ b/data/pop-js/forbidden-grove.js
@@ -31,7 +31,7 @@ module.exports = {
       config: [
         {
           opts: {
-            exclude: ["Glitchpaw"]
+            include: ["Realm Ripper"]
           }
         }
       ]

--- a/data/pop-js/laboratory.js
+++ b/data/pop-js/laboratory.js
@@ -1,18 +1,5 @@
 const utils = require("../_utils");
 
-const cheeses = [
-  "Radioactive Blue",
-  "Limelight",
-  "SB+",
-  "Gouda",
-  "Brie",
-  "Rancid Radioactive Blue",
-  "Magical Rancid Radioactive Blue",
-  "Swiss",
-  "Marble",
-  "Cheddar"
-];
-
 module.exports = {
   default: {
     location: utils.genVarField("location", "Laboratory"),
@@ -20,7 +7,30 @@ module.exports = {
   },
   series: [
     {
-      cheese: utils.genVarField("cheese", cheeses)
+      cheese: utils.genVarField("cheese", ["SB+", "Brie"])
+    },
+    {
+      cheese: utils.genVarField("cheese", [
+        "Gouda",
+        "Swiss",
+        "Marble",
+        "Cheddar"
+      ]),
+      config: [
+        {
+          opts: {
+            exclude: ["Burglar"]
+          }
+        }
+      ]
+    },
+    {
+      cheese: utils.genVarField("cheese", [
+        "Radioactive Blue",
+        "Rancid Radioactive Blue",
+        "Magical Rancid Radioactive Blue",
+        "Limelight"
+      ])
     }
   ]
 };

--- a/data/pop-js/living-garden.js
+++ b/data/pop-js/living-garden.js
@@ -19,7 +19,7 @@ module.exports = {
           },
           fields: { stage: "Not Poured" },
           opts: {
-            exclude: ["Thirsty", "Lucky"]
+            exclude: ["Thirsty", "Lucky", "Camofusion"]
           }
         }
       ]

--- a/data/pop-js/mousoleum.js
+++ b/data/pop-js/mousoleum.js
@@ -75,7 +75,14 @@ module.exports = {
     },
     {
       cheese: utils.genVarField("cheese", rbCheeses),
-      stage: utils.genVarField("stage", "Has Wall")
+      stage: utils.genVarField("stage", "Has Wall"),
+      config: [
+        {
+          opts: {
+            exclude: ["Glitchpaw", "Zombie"]
+          }
+        }
+      ]
     },
     {
       cheese: utils.genVarField("cheese", emCheeses),

--- a/data/pop-js/moussu-picchu.js
+++ b/data/pop-js/moussu-picchu.js
@@ -82,7 +82,7 @@ module.exports = {
           },
           fields: { stage: "Rain max", cheese: "Rainy" },
           opts: {
-            exclude: ["Monsoon Maker"]
+            exclude: ["Monsoon Maker", "Rain Summoner"]
           }
         }
       ]


### PR DESCRIPTION
- Acolyte Realm
- Cantera Quarry
- Catacombs
- Fiery Warpath (Portal-only)
- Forbidden Grove (excluded everything but Realm Ripper for Closed phase)
- Fort Rox
- Fungal Cavern
- Furoma Rift (new Training Grounds/Marble String PCC)
- Laboratory (Burglar only attracted to Brie/SB+, possibly since early Feb)
- Living Garden
- Mousoleum (Moz/No Wall/Undead Emmental has some weird numbers, so I left it unchanged)
- Moussu Picchu
- Prickly Plains
- Queso River
- Toxic Spill (some more mice in MRRB pops since it attracts errythang)