### PR TITLE
WIP: Wwrift comp data in CRE

### DIFF
--- a/cre.html
+++ b/cre.html
@@ -234,6 +234,17 @@
             <input name="salt" type="number" id="saltLevel" min="0" max="50" value="0" />
           </td>
         </tr>
+
+        <tr class="display-location display-whisker-woods-rift">
+          <td>Competition faction:</td>
+          <td>
+            <select id="wwriftFaction">
+              <option>Crazies</option>
+              <option>Gnarlies</option>
+              <option>Deepies</option>
+            </select>
+          </td>
+        </tr>
       </tbody>
 
       <tbody class="input-standard">

--- a/data/arrays.js
+++ b/data/arrays.js
@@ -158,6 +158,46 @@ var berglings = [
   "Snowblind"
 ];
 
+var compScoreTable = {
+  // CC low
+  "Bloomed Sylvan": 0,
+  "Cranky Caterpillar": 0,
+  "Mossy Moosker": 0,
+  // CC mid
+  "Treant Queen": 0, 
+  "Spirit Fox": 0,
+  "Red-Eyed Watcher Owl": 0,
+  // CC high
+  "Cyclops Barbarian": 0,
+    
+  // GG low
+  "Spirit of Balance": 3,
+  "Fungal Frog": 3,
+  "Karmachameleon": 3,
+  // GG mid
+  "Red Coat Bear": 2,
+  "Rift Tiger": 2,
+  "Nomadic Warrior": 2,
+  // GG high
+  "Centaur Ranger": 1,  
+
+  // DL low
+  "Twisted Treant": 3,
+  "Water Sprite": 3,
+  "Crazed Goblin": 3,
+  // DL mid
+  "Medicine": 2,
+  "Tree Troll": 2,
+  "Winged Harpy": 2,
+  // DL high
+  "Tri-dra": 1,
+
+  "Grizzled Silth": 0,  
+  "Cherry Sprite": 0,
+  "Naturalist": 0,
+  "Gilded Leaf": 0,
+}
+
 var catchDepth = {
   "Chipper": 16,
   "Frostlance Guard": 15,

--- a/data/arrays.js
+++ b/data/arrays.js
@@ -160,42 +160,42 @@ var berglings = [
 
 var compScoreTable = {
   // CC low
-  "Bloomed Sylvan": 0,
-  "Cranky Caterpillar": 0,
-  "Mossy Moosker": 0,
+  "Bloomed Sylvan":       {"Crazies": 0 , "Gnarlies": 3, "Deepies": 3}, 
+  "Cranky Caterpillar":   {"Crazies": 0 , "Gnarlies": 3, "Deepies": 3},
+  "Mossy Moosker":        {"Crazies": 0 , "Gnarlies": 3, "Deepies": 3},
   // CC mid
-  "Treant Queen": 0, 
-  "Spirit Fox": 0,
-  "Red-Eyed Watcher Owl": 0,
+  "Treant Queen":         {"Crazies": 0 , "Gnarlies": 2, "Deepies": 2}, 
+  "Spirit Fox":           {"Crazies": 0 , "Gnarlies": 2, "Deepies": 2},
+  "Red-Eyed Watcher Owl": {"Crazies": 0 , "Gnarlies": 2, "Deepies": 2},
   // CC high
-  "Cyclops Barbarian": 0,
+  "Cyclops Barbarian":    {"Crazies": 0 , "Gnarlies": 1, "Deepies": 1},
     
   // GG low
-  "Spirit of Balance": 3,
-  "Fungal Frog": 3,
-  "Karmachameleon": 3,
+  "Spirit of Balance":    {"Crazies": 3 , "Gnarlies": 0, "Deepies": 3},
+  "Fungal Frog":          {"Crazies": 3 , "Gnarlies": 0, "Deepies": 3},
+  "Karmachameleon":       {"Crazies": 3 , "Gnarlies": 0, "Deepies": 3},
   // GG mid
-  "Red Coat Bear": 2,
-  "Rift Tiger": 2,
-  "Nomadic Warrior": 2,
+  "Red Coat Bear":        {"Crazies": 2 , "Gnarlies": 0, "Deepies": 2},
+  "Rift Tiger":           {"Crazies": 2 , "Gnarlies": 0, "Deepies": 2},
+  "Nomadic Warrior":      {"Crazies": 2 , "Gnarlies": 0, "Deepies": 2},
   // GG high
-  "Centaur Ranger": 1,  
+  "Centaur Ranger":       {"Crazies": 1 , "Gnarlies": 0, "Deepies": 1},
 
   // DL low
-  "Twisted Treant": 3,
-  "Water Sprite": 3,
-  "Crazed Goblin": 3,
+  "Twisted Treant":       {"Crazies": 3 , "Gnarlies": 3, "Deepies": 0},
+  "Water Sprite":         {"Crazies": 3 , "Gnarlies": 3, "Deepies": 0},
+  "Crazed Goblin":        {"Crazies": 3 , "Gnarlies": 3, "Deepies": 0},
   // DL mid
-  "Medicine": 2,
-  "Tree Troll": 2,
-  "Winged Harpy": 2,
+  "Medicine":             {"Crazies": 2 , "Gnarlies": 2, "Deepies": 0},
+  "Tree Troll":           {"Crazies": 2 , "Gnarlies": 2, "Deepies": 0},
+  "Winged Harpy":         {"Crazies": 2 , "Gnarlies": 2, "Deepies": 0},
   // DL high
-  "Tri-dra": 1,
+  "Tri-dra":              {"Crazies": 1 , "Gnarlies": 1, "Deepies": 0},
 
-  "Grizzled Silth": 0,  
-  "Cherry Sprite": 0,
-  "Naturalist": 0,
-  "Gilded Leaf": 0,
+  "Grizzled Silth":       {"Crazies": 0 , "Gnarlies": 0, "Deepies": 0},
+  "Cherry Sprite":        {"Crazies": 0 , "Gnarlies": 0, "Deepies": 0},
+  "Naturalist":           {"Crazies": 0 , "Gnarlies": 0, "Deepies": 0},
+  "Gilded Leaf":          {"Crazies": 0 , "Gnarlies": 0, "Deepies": 0},
 }
 
 var catchDepth = {

--- a/src/main/cre.js
+++ b/src/main/cre.js
@@ -62,6 +62,8 @@ window.onload = function() {
   document.getElementById("saltLevel").onchange = saltChanged;
   document.getElementById("riftstalker").onchange = riftstalkerChange;
   document.getElementById("rank").onchange = rankChange;
+  document.getElementById("wwriftFaction").onchange = wwriftChange;
+
 
   document.getElementById("cheeseCost").onchange = function() {
     cheeseCost = parseInt(document.getElementById("cheeseCost").value);
@@ -405,7 +407,7 @@ function showPop(type) {
           mouseRow += "<td>" + dAmp + "%</td>";
           deltaAmpOverall += (dAmp * catches) / 100;
         } else if (locationName.indexOf("Whisker Woods Rift") >= 0) {
-          var compScore = compScoreTable[mouseName];
+          var compScore = compScoreTable[mouseName][wwriftFaction];
 
           mouseRow +=
             "<td>" + compScore + "</td>";
@@ -696,7 +698,8 @@ function updateLink() {
     cannonLevel: fortRox.cannonLevel,
     saltLevel: saltLevel,
     rank: rank,
-    amplifier: ztAmp
+    amplifier: ztAmp,
+    wwriftFaction: wwriftFaction
   };
   var URLString = buildURL("cre.html", urlParams);
   document.getElementById("link").href = URLString;

--- a/src/main/cre.js
+++ b/src/main/cre.js
@@ -267,6 +267,7 @@ function showPop(type) {
 
     var headerHTML = getHeaderRow();
     var overallAR = getCheeseAttraction();
+    var wwriftCompNormalizedAR = overallAR; // This will be corrected if some of the uncounted mice are in the list
     var resultsHTML = "<thead>" + headerHTML + "</thead><tbody>";
     var miceNames = Object.keys(popArrayLC || []);
 
@@ -407,12 +408,19 @@ function showPop(type) {
           mouseRow += "<td>" + dAmp + "%</td>";
           deltaAmpOverall += (dAmp * catches) / 100;
         } else if (locationName.indexOf("Whisker Woods Rift") >= 0) {
-          var compScore = compScoreTable[mouseName][wwriftFaction];
-
-          mouseRow +=
-            "<td>" + compScore + "</td>";
-
-          compScoreOverall += (((catchRate / 100) * compScore) * attractions) / 100;
+          if ((mouseName != "Gilded Leaf") &&
+              (mouseName != "Grizzled Silth") &&
+              (mouseName != "Cherry Sprite") &&
+              (mouseName != "Naturalist") &&
+              (mouseName != "Monstrous Black Widow"))
+           {
+            var compScore = compScoreTable[mouseName][wwriftFaction];
+            mouseRow += "<td>" + compScore + "</td>";
+            compScoreOverall += (compScore * attractions) / 100;
+          } else {
+            mouseRow += "<td>Not counted</td>";
+            wwriftCompNormalizedAR -= (attractions / 100.0);
+          }
         }
         else if (
           contains(locationName, "Iceberg") &&
@@ -526,7 +534,8 @@ function showPop(type) {
       deltaAmpOverall += ((100 - overallAR) / 100) * -3; // Accounting for FTAs (-3%)
       resultsHTML += "<td>" + deltaAmpOverall.toFixed(2) + "%</td>";
     } else if (locationName.indexOf("Whisker Woods Rift") >= 0) {
-      resultsHTML += "<td>" + compScoreOverall.toFixed(2) + "</td>";
+      var normalizedScore = compScoreOverall / wwriftCompNormalizedAR;
+      resultsHTML += "<td>" + normalizedScore.toFixed(2) + "</td>";
     } else if (
       contains(locationName, "Iceberg") &&
       phaseName.indexOf("Lair") < 0

--- a/src/main/cre.js
+++ b/src/main/cre.js
@@ -202,7 +202,9 @@ function showPop(type) {
 
     if (locationName.indexOf("Seasonal Garden") >= 0) {
       headerHTML += "<th data-filter='false'>Amp %</th>";
-    } else if (
+    } else if (locationName.indexOf("Whisker Woods Rift") >= 0) {
+      headerHTML += "<th data-filter='false'>Comp score</th>";
+    }else if (
       contains(locationName, "Iceberg") &&
       phaseName.indexOf("Lair") < 0
     ) {
@@ -248,6 +250,7 @@ function showPop(type) {
 
     var deltaAmpOverall = 0,
       deltaDepthOverall = 0,
+      compScoreOverall = 0,
       depthTest = 0,
       diveMPH = 0,
       avgLanternClues = 0,
@@ -401,7 +404,15 @@ function showPop(type) {
 
           mouseRow += "<td>" + dAmp + "%</td>";
           deltaAmpOverall += (dAmp * catches) / 100;
-        } else if (
+        } else if (locationName.indexOf("Whisker Woods Rift") >= 0) {
+          var compScore = compScoreTable[mouseName];
+
+          mouseRow +=
+            "<td>" + compScore + "</td>";
+
+          compScoreOverall += (((catchRate / 100) * compScore) * attractions) / 100;
+        }
+        else if (
           contains(locationName, "Iceberg") &&
           phaseName.indexOf("Lair") < 0
         ) {
@@ -512,6 +523,8 @@ function showPop(type) {
     if (locationName.indexOf("Seasonal Garden") >= 0) {
       deltaAmpOverall += ((100 - overallAR) / 100) * -3; // Accounting for FTAs (-3%)
       resultsHTML += "<td>" + deltaAmpOverall.toFixed(2) + "%</td>";
+    } else if (locationName.indexOf("Whisker Woods Rift") >= 0) {
+      resultsHTML += "<td>" + compScoreOverall.toFixed(2) + "</td>";
     } else if (
       contains(locationName, "Iceberg") &&
       phaseName.indexOf("Lair") < 0
@@ -580,7 +593,8 @@ function showPop(type) {
 
     if (
       locationName.indexOf("Seasonal Garden") >= 0 ||
-      (locationName.indexOf("Sunken City") >= 0 && phaseName != "Docked")
+      locationName.indexOf("Whisker Woods Rift") >= 0 ||
+      (locationName.indexOf("Sunken City") >= 0 && phaseName != "Docked") 
     ) {
       resultsHTML += "<td></td>";
     } else if (

--- a/src/main/setup.js
+++ b/src/main/setup.js
@@ -55,6 +55,7 @@ $(window).load(function() {
   document.getElementById("saltLevel").onchange = saltChanged;
   document.getElementById("riftstalker").onchange = riftstalkerChange;
   document.getElementById("rank").onchange = rankChange;
+  document.getElementById("wwriftFaction").onchange = wwriftChange;
 
   $("#save_setup_button").click(saveSetupStorage);
 
@@ -417,7 +418,8 @@ function updateLink() {
     cannonLevel: fortRox.cannonLevel,
     saltLevel: saltLevel,
     rank: rank,
-    amplifier: ztAmp
+    amplifier: ztAmp,
+    wwriftFaction: wwriftFaction
   };
 
   var urlString = buildURL("setup.html", urlParams);
@@ -791,7 +793,8 @@ function getCRELinkElement() {
       cannonLevel: fortRox.cannonLevel,
       saltLevel: saltLevel,
       rank: rank,
-      amplifier: ztAmp
+      amplifier: ztAmp,
+      wwriftFaction: wwriftFaction
     };
     var urlString = buildURL("cre.html", urlParams);
     urlString = urlString.replace(/'/g, "%27"); //TODO: Verify necessity

--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -76,6 +76,9 @@ var fortRox = {
 // Initialize Sand Crypts salt level
 var saltLevel = 0;
 
+// Initialize WWRift faction
+var wwriftFaction = "Crazies"
+
 /**
  * Returns the size of an object based on its length or number of keys
  * @param {object} obj
@@ -633,6 +636,10 @@ function sandCryptsParamCheck() {
   updateInputFromParameter("saltLevel", saltChanged);
 }
 
+function wwriftParamCheck() {
+  updateInputFromParameter("wwriftFaction", wwriftChange);
+}
+
 function getRankKey() {
   return "rank-" + user;
 }
@@ -864,6 +871,11 @@ function gsChanged() {
 
 function saltChanged() {
   saltLevel = document.getElementById("saltLevel").value;
+  genericOnChange();
+}
+
+function wwriftChange() {
+  wwriftFaction = document.getElementById("wwriftFaction").value;
   genericOnChange();
 }
 
@@ -1451,6 +1463,7 @@ function checkLoadState(type) {
     riftstalkerParamCheck();
     fortRoxParamCheck();
     sandCryptsParamCheck();
+    wwriftParamCheck();
     rankParamCheck();
     golemParamCheck();
 


### PR DESCRIPTION
This proposal adds a column to the CRE for WWrift with the average amount of points per hunt.

Marked as WIP as the way it's currently implemented makes it tedious to remove again later. Just wanted to show what the general idea is and check if such event-only data is generally avoided in the tool or not.