### PR TITLE
Updated Prestige to reflect new normal

### DIFF
--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -1699,7 +1699,7 @@ function calcPrestigeStats() {
   // Initial: 490 Power, 20% Power Bonus, 0% Attraction Bonus, 5 Luck, No Effect
   if (umbraFloor > 0 && umbraFloor <= 200) {
     basePower = 490 + umbraFloor * 20;
-    baseLuck = 5 + Math.floor((umbraFloor - 1) / 8) * 2;
+    baseLuck = 5 + Math.floor(umbraFloor / 8) * 2;
   }
 }
 

--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -1698,8 +1698,8 @@ function calcSaltedPower(type, mousePower) {
 function calcPrestigeStats() {
   // Initial: 490 Power, 20% Power Bonus, 0% Attraction Bonus, 5 Luck, No Effect
   if (umbraFloor > 0 && umbraFloor <= 200) {
-    basePower = 490 + umbraFloor * 10;
-    baseLuck = 5 + Math.floor((umbraFloor - 1) / 8);
+    basePower = 490 + umbraFloor * 20;
+    baseLuck = 5 + Math.floor((umbraFloor - 1) / 8) * 2;
   }
 }
 

--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -505,9 +505,9 @@ function calculateTrapSetup(skipDisp) {
     if (tauntBonus === 1) riftCount += 1;
 
     if (riftCount === 2) {
-      shownPowerBonus += 10 * multiplier;
+      shownPowerBonus += 20 * multiplier;
     } else if (riftCount === 3) {
-      shownPowerBonus += 10 * multiplier;
+      shownPowerBonus += 20 * multiplier;
       specialLuck += 5 * multiplier;
     }
   }


### PR DESCRIPTION
Revealed in FBF today prestige displayed the wrong values, as we suspected. Turns out it's 20 power per floor and 2 luck per eclipse floor.

I don't suggest making the change until the patch notes are published.