### PR TITLE
Fix rift power bonus in power tools

### DIFF
--- a/src/main/powers-worksheet.js
+++ b/src/main/powers-worksheet.js
@@ -619,7 +619,7 @@ function processInput(inputText) {
       +(riftCharms.indexOf(user.charm) > -1 || user.charm.indexOf("Rift") > -1);
     if (riftCount >= 2) {
       // 2 or 3 triggers the power bonus of Rift set
-      bonusObj["rift"] = 10 * riftMultiplier;
+      bonusObj["rift"] = 20 * riftMultiplier;
     }
   }
 

--- a/src/main/powers.js
+++ b/src/main/powers.js
@@ -424,7 +424,7 @@ function generateResults() {
                 +(riftCharms.indexOf(charm) > -1 || charm.indexOf("Rift") > -1);
               if (riftCount >= 2) {
                 // 2 or 3 triggers the power bonus of Rift set
-                bonusObj["rift"] = 10 * riftMultiplier;
+                bonusObj["rift"] = 20 * riftMultiplier;
               }
             }
 
@@ -502,7 +502,7 @@ function generateResults() {
                   );
                 if (riftCount >= 2) {
                   // 2 or 3 triggers the power bonus of Rift set
-                  bonusObj["rift"] = 10 * riftMultiplier;
+                  bonusObj["rift"] = 20 * riftMultiplier;
                 }
               }
 


### PR DESCRIPTION
Power tool and worksheet were not updated when prestige base display was fixed. 
Correctly set the power bonus per level to 20 in these tools.

Fixes #130 