### PR TITLE
Create edge case for Ambush Trap in Best Setup: Fields

### DIFF
--- a/src/bookmarklet/bm-setup-fields.js
+++ b/src/bookmarklet/bm-setup-fields.js
@@ -540,8 +540,13 @@
   }
 
   // Weapon edge cases
-  if (urlParams["weapon"] === "School of Sharks Trap") {
-    urlParams["weapon"] = "School of Sharks";
+  switch(urlParams["weapon"]){
+    case "School of Sharks Trap":
+      urlParams["weapon"] = "School of Sharks";
+      break;
+    case "Ambush Trap":
+      urlParams["weapon"] = "Ambush";
+      break
   }
 
   if (userSublocation !== "N/A") {

--- a/src/bookmarklet/bm-setup-fields.js
+++ b/src/bookmarklet/bm-setup-fields.js
@@ -540,13 +540,13 @@
   }
 
   // Weapon edge cases
-  switch(urlParams["weapon"]){
+  switch (urlParams["weapon"]) {
     case "School of Sharks Trap":
       urlParams["weapon"] = "School of Sharks";
       break;
     case "Ambush Trap":
       urlParams["weapon"] = "Ambush";
-      break
+      break;
   }
 
   if (userSublocation !== "N/A") {

--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -1526,7 +1526,8 @@ function checkLoadState(type) {
     }
 
     if (type === SETUP_USER) {
-      weaponName = getURLParameter("weapon");
+      weaponCheck = getURLParameter("weapon");
+      weaponName = (weaponCheck == "Ambush Trap") ? "Ambush" : weaponCheck;
       weaponChanged();
       baseName = getURLParameter("base");
       baseChanged();

--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -166,7 +166,7 @@ function getURLParameter(name) {
     return null;
   } else if (name === "weapon") {
     let weaponCheck = decodeURIComponent(value);
-    switch (weaponCheck){
+    switch (weaponCheck) {
       case "Ambush Trap":
         return "Ambush";
       case "School Of Sharks Trap":

--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -164,6 +164,16 @@ function getURLParameter(name) {
 
   if (value === null) {
     return null;
+  } else if (name === "weapon") {
+    let weaponCheck = decodeURIComponent(value);
+    switch (weaponCheck){
+      case "Ambush Trap":
+        return "Ambush";
+      case "School Of Sharks Trap":
+        return "School of Sharks";
+      default:
+        return weaponCheck;
+    }
   } else {
     return decodeURIComponent(value);
   }
@@ -892,13 +902,6 @@ function loadDropdown(category, array, callback, initialHtml) {
   } else {
     var paramVal = getURLParameter(category);
     inputElement.value = paramVal;
-
-    if (category === "weapon") {
-      // Weapon edge cases
-      if (paramVal === "Ambush Trap") {
-        inputElement.value = "Ambush";
-      }
-    }
   }
 
   if (inputElement.selectedIndex === -1) {
@@ -1526,8 +1529,8 @@ function checkLoadState(type) {
     }
 
     if (type === SETUP_USER) {
-      weaponCheck = getURLParameter("weapon");
-      weaponName = (weaponCheck == "Ambush Trap") ? "Ambush" : weaponCheck;
+      //check for weapon edge cases in Setup
+      weaponName = getURLParameter("weapon");
       weaponChanged();
       baseName = getURLParameter("base");
       baseChanged();

--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -1529,7 +1529,6 @@ function checkLoadState(type) {
     }
 
     if (type === SETUP_USER) {
-      //check for weapon edge cases in Setup
       weaponName = getURLParameter("weapon");
       weaponChanged();
       baseName = getURLParameter("base");


### PR DESCRIPTION
Moved edge case check into `getURLParameters` within `shared-cre-setup.js` to ensure that it is checked in both CRE and Setup.
Created edge case in bookmarklet Best Setup: Fields to account for Ambush Trap in addition to School of Sharks

<hr/>

Description of issue:

when Ambush Trap is passed as a parameter in the URL in "Best Setup:Fields" it leaves the tool stuck at "Loading 100%"

App will break in `shared-cre-setup.js` on line 265 when `weaponsArray[weaponName][0]` returns undefined as `weaponName` is "Ambush Trap" and not "Ambush".

The weapon edge case in `shared-cre-setup.js` line 898 never gets hit in the best setup tool, it only applies in catch rate estimator