### PR TITLE
Update CR and minluck formula to account for floating-point errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ New minimum luck formula: <img src="https://render.githubusercontent.com/render/
 - L = Trap Luck
 - M = Mouse Power
 
+For minimum luck, there's an extra wrinkle due to floating point arithmetic errors in MouseHunt. To match MouseHunt in detail, all of the above formulas must be computed using 64-bit floating point arithmetic. Then, check if the minimum luck is actually enough to guarantee 100% catch rate (i.e. if `2 * floor(min(1.4, E) * L)^2 >= M`); if not, increment the minluck by 1. This is described further by [beeejk's post](https://mh.beeejk.net/minluck).
+
 #### &sect; Sample Size Score
 
 An indicator of the quality and accuracy of a specific setup's data based on its sample size and the number of mice in its attraction pool. Setups are separated by locations, sublocations, cheeses and occasionally charms (if they have attraction-altering effects i.e. Warpath Warrior Charm in Waves 1-3 of Fiery Warpath). If you have a charm selected that doesn't affect a setup's mouse population pool, its corresponding "No Charm" data is displayed, since they are equivalent.

--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -580,11 +580,7 @@ function calcCR(effectiveness, trapPower, trapLuck, mousePower) {
 
   var catchRate =
     (effectiveness * trapPower +
-      2 *
-        Math.pow(
-          Math.floor((Math.min(effectiveness * 10, 14) * trapLuck) / 10),
-          2
-        )) /
+      2 * Math.pow(Math.floor(Math.min(effectiveness, 1.4) * trapLuck), 2)) /
     (effectiveness * trapPower + mousePower);
 
   return Math.min(catchRate, 1);
@@ -604,10 +600,16 @@ function minLuck(effectiveness, mousePower) {
   //   mousePower / (3 - finalEffectiveness) / Math.pow(finalEffectiveness, 2);
   // return Math.ceil(Math.sqrt(minLuckSquared));
 
-  return Math.ceil(
-    (Math.ceil(Math.sqrt(mousePower / 2)) / Math.min(effectiveness * 10, 14)) *
-      10
+  var candidateMinluck = Math.ceil(
+    Math.ceil(Math.sqrt(mousePower / 2)) / Math.min(effectiveness, 1.4)
   );
+
+  // If, due to floating-point errors, the candidate minluck is not
+  // actually enough, add one. (This is described further in the README.)
+  if calcCR(effectiveness, 0, candidateMinluck, mousePower) < 1 {
+    return candidateMinluck + 1
+  }
+  return candidateMinluck
 }
 
 /**


### PR DESCRIPTION
Dave has confirmed that the minluck of Zealous Academic is in fact 86,
not 85. My theory for this is that it's because of floating point errors
in MouseHunt (and indeed Dave hinted that the explanation was a silly
quirk, not an originally intended part of the formula). This theory is
described in further detail at https://mh.beeejk.net/minluck (and has
been discussed in Discord).

The fixes for CRE are pretty simple; we just have to remove the care the
code was taking to avoid floating-point errors! And then for minluck we
need to check if the error is happening, and if so increment by 1. I
also added to the README an abbreviated explanation and a link to the
full explanation.

Let me know if there's anywhere other than the README that I should
surface the change to users.