### PR TITLE
Remove "bookmarklet has been updated" alert

### DIFF
--- a/src/utils/bookmarklets.js
+++ b/src/utils/bookmarklets.js
@@ -47,16 +47,6 @@ function loadBookmarkletFromJS(url, storageKey, linkSelector) {
       powersBookmarklet: "Powers Worksheet"
     };
 
-    if (bookmarkletString !== localStorage.getItem(storageKey)) {
-      var alertString =
-        "The " + keyMap[storageKey] + " bookmarklet has been updated.";
-      if (storageKey !== "bookmarkletLoader") {
-        alertString += "\nPlease edit accordingly, or try the Auto-Loader!";
-      }
-      alert(alertString);
-      localStorage.setItem(storageKey, bookmarkletString);
-    }
-
     $(linkSelector).attr("href", bookmarkletString);
     $(linkSelector + "Copy").click(function() {
       var tempCopyArea = document.createElement("textarea");


### PR DESCRIPTION
Right now, every single user gets an `alert()` fired in their face on the very first visit to any page. The annoyance of that + the fact that the alert does *not* get triggered when it has been updated means it should just be removed.