### PR TITLE
Treat Iceberg Boiler Base like UIB

### DIFF
--- a/src/bookmarklet/bm-cre.js
+++ b/src/bookmarklet/bm-cre.js
@@ -143,7 +143,8 @@
         (sublocation === "Treacherous Tunnels" ||
           sublocation === "Bombing Run" ||
           sublocation === "The Mad Depths") &&
-        userBase === "Ultimate Iceberg Base"
+        (userBase === "Ultimate Iceberg Base" ||
+          userBase === "Iceberg Boiler Base")
       ) {
         return sublocation + " (Ultimate Iceberg)";
       }

--- a/src/main/shared-cre-setup.js
+++ b/src/main/shared-cre-setup.js
@@ -374,13 +374,14 @@ function calculateTrapSetup(skipDisp) {
         specialLuck += 2;
       }
 
-      // Deep Freeze / UIB bonuses before hunt 250
+      // Deep Freeze / UIB / IBB bonuses before hunt 250
       if (
         (phaseName.indexOf("Icewing's Lair") >= 0 ||
           phaseName.indexOf("Hidden Depths") >= 0 ||
           phaseName.indexOf("The Deep Lair") >= 0) &&
         (baseName === "Deep Freeze Base" ||
-          baseName === "Ultimate Iceberg Base")
+          baseName === "Ultimate Iceberg Base" ||
+          baseName === "Iceberg Boiler Base")
       ) {
         specialPower += 665;
         specialLuck += 9;


### PR DESCRIPTION
The Iceberg Boiler Base acts the same as the Ultimate Iceberg Base. Have the CRE bookmarklet set the sublocation to the UIB-specific ones where applicable. It also gets the same stat bonus as UIB and Deep Freeze in the Lair and beyond.

fixes #200 