### PR TITLE
Re-add HoTM back to Fort Rox

### DIFF
--- a/data/pop-csv/fort-rox.csv
+++ b/data/pop-csv/fort-rox.csv
@@ -1,244 +1,245 @@
 "Location","Phase","Cheese","Charm","Attraction Rate","Mouse","Sample Size"
-"Fort Rox","Day","Gouda","-","29.80%","Mischievous Meteorite Miner",166564
-"Fort Rox","Day","Gouda","-","29.76%","Meteorite Miner",166564
-"Fort Rox","Day","Gouda","-","17.59%","Hardworking Hauler",166564
-"Fort Rox","Day","Gouda","-","11.89%","Meteorite Snacker",166564
-"Fort Rox","Day","Gouda","-","5.98%","Meteorite Mover",166564
-"Fort Rox","Day","Gouda","-","4.99%","Mining Materials Manager",166564
-"Fort Rox","Day","Brie","-","29.81%","Mischievous Meteorite Miner",28813
-"Fort Rox","Day","Brie","-","29.40%","Meteorite Miner",28813
-"Fort Rox","Day","Brie","-","18.09%","Hardworking Hauler",28813
-"Fort Rox","Day","Brie","-","11.95%","Meteorite Snacker",28813
-"Fort Rox","Day","Brie","-","5.93%","Meteorite Mover",28813
-"Fort Rox","Day","Brie","-","4.81%","Mining Materials Manager",28813
-"Fort Rox","Day","SB+","-","24.46%","Meteorite Miner",8925
-"Fort Rox","Day","SB+","-","23.61%","Mischievous Meteorite Miner",8925
-"Fort Rox","Day","SB+","-","17.95%","Hardworking Hauler",8925
-"Fort Rox","Day","SB+","-","16.09%","Mining Materials Manager",8925
-"Fort Rox","Day","SB+","-","15.37%","Meteorite Snacker",8925
-"Fort Rox","Day","SB+","-","2.52%","Meteorite Mover",8925
-"Fort Rox","Day","Crescent","-","25.20%","Mischievous Meteorite Miner",5477
-"Fort Rox","Day","Crescent","-","25.14%","Meteorite Miner",5477
-"Fort Rox","Day","Crescent","-","19.41%","Meteorite Snacker",5477
-"Fort Rox","Day","Crescent","-","15.45%","Hardworking Hauler",5477
-"Fort Rox","Day","Crescent","-","10.74%","Meteorite Mover",5477
-"Fort Rox","Day","Crescent","-","4.07%","Mining Materials Manager",5477
-"Fort Rox","Day","Moon","-","32.68%","Meteorite Snacker",3005
-"Fort Rox","Day","Moon","-","22.83%","Mischievous Meteorite Miner",3005
-"Fort Rox","Day","Moon","-","20.37%","Meteorite Miner",3005
-"Fort Rox","Day","Moon","-","11.31%","Meteorite Mover",3005
-"Fort Rox","Day","Moon","-","8.55%","Hardworking Hauler",3005
-"Fort Rox","Day","Moon","-","4.26%","Mining Materials Manager",3005
-"Fort Rox","Twilight","Gouda","-","28.39%","Battering Ram",3684
-"Fort Rox","Twilight","Gouda","-","17.37%","Werehauler",3684
-"Fort Rox","Twilight","Gouda","-","14.69%","Mischievous Wereminer",3684
-"Fort Rox","Twilight","Gouda","-","13.03%","Reveling Lycanthrope",3684
-"Fort Rox","Twilight","Gouda","-","11.94%","Nightmancer",3684
-"Fort Rox","Twilight","Gouda","-","8.60%","Wereminer",3684
-"Fort Rox","Twilight","Gouda","-","5.97%","Alpha Weremouse",3684
-"Fort Rox","Twilight","Brie","-","26.22%","Battering Ram",164
-"Fort Rox","Twilight","Brie","-","17.07%","Nightmancer",164
-"Fort Rox","Twilight","Brie","-","14.63%","Mischievous Wereminer",164
-"Fort Rox","Twilight","Brie","-","14.02%","Werehauler",164
-"Fort Rox","Twilight","Brie","-","10.37%","Reveling Lycanthrope",164
-"Fort Rox","Twilight","Brie","-","10.37%","Wereminer",164
-"Fort Rox","Twilight","Brie","-","7.32%","Alpha Weremouse",164
-"Fort Rox","Twilight","SB+","-","18.23%","Battering Ram",631
-"Fort Rox","Twilight","SB+","-","16.32%","Werehauler",631
-"Fort Rox","Twilight","SB+","-","16.32%","Mischievous Wereminer",631
-"Fort Rox","Twilight","SB+","-","12.68%","Nightmancer",631
-"Fort Rox","Twilight","SB+","-","12.36%","Alpha Weremouse",631
-"Fort Rox","Twilight","SB+","-","11.41%","Reveling Lycanthrope",631
-"Fort Rox","Twilight","SB+","-","9.03%","Wereminer",631
-"Fort Rox","Twilight","SB+","-","3.65%","Night Shift Materials Manager",631
-"Fort Rox","Twilight","Crescent","-","22.85%","Werehauler",104182
-"Fort Rox","Twilight","Crescent","-","18.93%","Alpha Weremouse",104182
-"Fort Rox","Twilight","Crescent","-","15.61%","Reveling Lycanthrope",104182
-"Fort Rox","Twilight","Crescent","-","14.78%","Mischievous Wereminer",104182
-"Fort Rox","Twilight","Crescent","-","14.78%","Wereminer",104182
-"Fort Rox","Twilight","Crescent","-","7.93%","Night Shift Materials Manager",104182
-"Fort Rox","Twilight","Crescent","-","5.11%","Nightmancer",104182
-"Fort Rox","Twilight","Moon","-","20.37%","Mischievous Wereminer",27432
-"Fort Rox","Twilight","Moon","-","18.76%","Alpha Weremouse",27432
-"Fort Rox","Twilight","Moon","-","16.50%","Werehauler",27432
-"Fort Rox","Twilight","Moon","-","15.97%","Wereminer",27432
-"Fort Rox","Twilight","Moon","-","13.78%","Reveling Lycanthrope",27432
-"Fort Rox","Twilight","Moon","-","9.76%","Night Shift Materials Manager",27432
-"Fort Rox","Twilight","Moon","-","4.84%","Nightmancer",27432
-"Fort Rox","Midnight","Gouda","-","26.87%","Battering Ram",748
-"Fort Rox","Midnight","Gouda","-","15.24%","Werehauler",748
-"Fort Rox","Midnight","Gouda","-","15.24%","Nightmancer",748
-"Fort Rox","Midnight","Gouda","-","9.76%","Alpha Weremouse",748
-"Fort Rox","Midnight","Gouda","-","7.49%","Mischievous Wereminer",748
-"Fort Rox","Midnight","Gouda","-","5.48%","Hypnotized Gunslinger",748
-"Fort Rox","Midnight","Gouda","-","5.21%","Night Watcher",748
-"Fort Rox","Midnight","Gouda","-","4.28%","Meteorite Golem",748
-"Fort Rox","Midnight","Gouda","-","3.48%","Wereminer",748
-"Fort Rox","Midnight","Gouda","-","2.94%","Arcane Summoner",748
-"Fort Rox","Midnight","Gouda","-","2.27%","Wealthy Werewarrior",748
-"Fort Rox","Midnight","Gouda","-","1.74%","Reveling Lycanthrope",748
-"Fort Rox","Midnight","SB+","-","16.02%","Battering Ram",181
-"Fort Rox","Midnight","SB+","-","15.47%","Nightmancer",181
-"Fort Rox","Midnight","SB+","-","13.26%","Werehauler",181
-"Fort Rox","Midnight","SB+","-","11.05%","Alpha Weremouse",181
-"Fort Rox","Midnight","SB+","-","8.29%","Hypnotized Gunslinger",181
-"Fort Rox","Midnight","SB+","-","6.63%","Night Shift Materials Manager",181
-"Fort Rox","Midnight","SB+","-","6.08%","Mischievous Wereminer",181
-"Fort Rox","Midnight","SB+","-","6.08%","Night Watcher",181
-"Fort Rox","Midnight","SB+","-","4.97%","Wereminer",181
-"Fort Rox","Midnight","SB+","-","3.87%","Reveling Lycanthrope",181
-"Fort Rox","Midnight","SB+","-","3.87%","Arcane Summoner",181
-"Fort Rox","Midnight","SB+","-","3.31%","Meteorite Golem",181
-"Fort Rox","Midnight","SB+","-","1.10%","Wealthy Werewarrior",181
-"Fort Rox","Midnight","Crescent","-","13.72%","Alpha Weremouse",59579
-"Fort Rox","Midnight","Crescent","-","13.07%","Werehauler",59579
-"Fort Rox","Midnight","Crescent","-","11.75%","Nightmancer",59579
-"Fort Rox","Midnight","Crescent","-","9.96%","Wealthy Werewarrior",59579
-"Fort Rox","Midnight","Crescent","-","9.94%","Mischievous Wereminer",59579
-"Fort Rox","Midnight","Crescent","-","9.03%","Wereminer",59579
-"Fort Rox","Midnight","Crescent","-","7.81%","Night Shift Materials Manager",59579
-"Fort Rox","Midnight","Crescent","-","6.03%","Hypnotized Gunslinger",59579
-"Fort Rox","Midnight","Crescent","-","5.17%","Reveling Lycanthrope",59579
-"Fort Rox","Midnight","Crescent","-","4.81%","Night Watcher",59579
-"Fort Rox","Midnight","Crescent","-","4.79%","Arcane Summoner",59579
-"Fort Rox","Midnight","Crescent","-","3.92%","Meteorite Golem",59579
-"Fort Rox","Midnight","Moon","-","18.51%","Alpha Weremouse",18831
-"Fort Rox","Midnight","Moon","-","11.05%","Mischievous Wereminer",18831
-"Fort Rox","Midnight","Moon","-","10.03%","Night Shift Materials Manager",18831
-"Fort Rox","Midnight","Moon","-","9.97%","Wereminer",18831
-"Fort Rox","Midnight","Moon","-","9.93%","Nightmancer",18831
-"Fort Rox","Midnight","Moon","-","9.59%","Wealthy Werewarrior",18831
-"Fort Rox","Midnight","Moon","-","6.28%","Werehauler",18831
-"Fort Rox","Midnight","Moon","-","5.23%","Reveling Lycanthrope",18831
-"Fort Rox","Midnight","Moon","-","5.09%","Hypnotized Gunslinger",18831
-"Fort Rox","Midnight","Moon","-","4.90%","Arcane Summoner",18831
-"Fort Rox","Midnight","Moon","-","4.84%","Night Watcher",18831
-"Fort Rox","Midnight","Moon","-","4.60%","Meteorite Golem",18831
-"Fort Rox","Pitch","Gouda","-","40.28%","Battering Ram",216
-"Fort Rox","Pitch","Gouda","-","10.65%","Hypnotized Gunslinger",216
-"Fort Rox","Pitch","Gouda","-","9.72%","Nightmancer",216
-"Fort Rox","Pitch","Gouda","-","9.72%","Nightfire",216
-"Fort Rox","Pitch","Gouda","-","6.02%","Meteorite Mystic",216
-"Fort Rox","Pitch","Gouda","-","6.02%","Night Watcher",216
-"Fort Rox","Pitch","Gouda","-","4.63%","Cursed Taskmaster",216
-"Fort Rox","Pitch","Gouda","-","3.24%","Arcane Summoner",216
-"Fort Rox","Pitch","Gouda","-","3.24%","Meteorite Golem",216
-"Fort Rox","Pitch","Gouda","-","2.31%","Alpha Weremouse",216
-"Fort Rox","Pitch","Gouda","-","1.39%","Mischievous Wereminer",216
-"Fort Rox","Pitch","Gouda","-","0.93%","Wereminer",216
-"Fort Rox","Pitch","Gouda","-","0.93%","Wealthy Werewarrior",216
-"Fort Rox","Pitch","Gouda","-","0.46%","Werehauler",216
-"Fort Rox","Pitch","Gouda","-","0.46%","Reveling Lycanthrope",216
-"Fort Rox","Pitch","Crescent","-","14.52%","Hypnotized Gunslinger",19291
-"Fort Rox","Pitch","Crescent","-","10.44%","Nightmancer",19291
-"Fort Rox","Pitch","Crescent","-","9.80%","Wealthy Werewarrior",19291
-"Fort Rox","Pitch","Crescent","-","9.15%","Nightfire",19291
-"Fort Rox","Pitch","Crescent","-","7.75%","Night Shift Materials Manager",19291
-"Fort Rox","Pitch","Crescent","-","6.92%","Meteorite Golem",19291
-"Fort Rox","Pitch","Crescent","-","6.16%","Alpha Weremouse",19291
-"Fort Rox","Pitch","Crescent","-","5.13%","Werehauler",19291
-"Fort Rox","Pitch","Crescent","-","5.08%","Night Watcher",19291
-"Fort Rox","Pitch","Crescent","-","5.06%","Wereminer",19291
-"Fort Rox","Pitch","Crescent","-","4.97%","Arcane Summoner",19291
-"Fort Rox","Pitch","Crescent","-","4.82%","Cursed Taskmaster",19291
-"Fort Rox","Pitch","Crescent","-","4.00%","Reveling Lycanthrope",19291
-"Fort Rox","Pitch","Crescent","-","3.14%","Mischievous Wereminer",19291
-"Fort Rox","Pitch","Crescent","-","3.06%","Meteorite Mystic",19291
-"Fort Rox","Pitch","Moon","-","15.05%","Hypnotized Gunslinger",7788
-"Fort Rox","Pitch","Moon","-","10.77%","Night Shift Materials Manager",7788
-"Fort Rox","Pitch","Moon","-","10.49%","Wealthy Werewarrior",7788
-"Fort Rox","Pitch","Moon","-","9.53%","Nightmancer",7788
-"Fort Rox","Pitch","Moon","-","7.22%","Meteorite Golem",7788
-"Fort Rox","Pitch","Moon","-","6.52%","Alpha Weremouse",7788
-"Fort Rox","Pitch","Moon","-","5.60%","Wereminer",7788
-"Fort Rox","Pitch","Moon","-","5.53%","Night Watcher",7788
-"Fort Rox","Pitch","Moon","-","4.96%","Meteorite Mystic",7788
-"Fort Rox","Pitch","Moon","-","4.96%","Arcane Summoner",7788
-"Fort Rox","Pitch","Moon","-","4.84%","Cursed Taskmaster",7788
-"Fort Rox","Pitch","Moon","-","4.67%","Nightfire",7788
-"Fort Rox","Pitch","Moon","-","3.79%","Reveling Lycanthrope",7788
-"Fort Rox","Pitch","Moon","-","3.25%","Mischievous Wereminer",7788
-"Fort Rox","Pitch","Moon","-","2.82%","Werehauler",7788
-"Fort Rox","Utter Darkness","Gouda","-","66.59%","Battering Ram",428
-"Fort Rox","Utter Darkness","Gouda","-","11.45%","Nightfire",428
-"Fort Rox","Utter Darkness","Gouda","-","4.44%","Nightmancer",428
-"Fort Rox","Utter Darkness","Gouda","-","3.04%","Cursed Taskmaster",428
-"Fort Rox","Utter Darkness","Gouda","-","2.80%","Meteorite Mystic",428
-"Fort Rox","Utter Darkness","Gouda","-","2.34%","Hypnotized Gunslinger",428
-"Fort Rox","Utter Darkness","Gouda","-","2.10%","Meteorite Golem",428
-"Fort Rox","Utter Darkness","Gouda","-","2.10%","Alpha Weremouse",428
-"Fort Rox","Utter Darkness","Gouda","-","1.87%","Night Watcher",428
-"Fort Rox","Utter Darkness","Gouda","-","1.40%","Wereminer",428
-"Fort Rox","Utter Darkness","Gouda","-","1.17%","Reveling Lycanthrope",428
-"Fort Rox","Utter Darkness","Gouda","-","0.23%","Arcane Summoner",428
-"Fort Rox","Utter Darkness","Gouda","-","0.23%","Wealthy Werewarrior",428
-"Fort Rox","Utter Darkness","Gouda","-","0.23%","Mischievous Wereminer",428
-"Fort Rox","Utter Darkness","Crescent","-","14.88%","Hypnotized Gunslinger",36973
-"Fort Rox","Utter Darkness","Crescent","-","12.13%","Nightfire",36973
-"Fort Rox","Utter Darkness","Crescent","-","12.04%","Meteorite Golem",36973
-"Fort Rox","Utter Darkness","Crescent","-","11.85%","Cursed Taskmaster",36973
-"Fort Rox","Utter Darkness","Crescent","-","9.89%","Night Watcher",36973
-"Fort Rox","Utter Darkness","Crescent","-","7.74%","Meteorite Mystic",36973
-"Fort Rox","Utter Darkness","Crescent","-","6.90%","Alpha Weremouse",36973
-"Fort Rox","Utter Darkness","Crescent","-","5.82%","Arcane Summoner",36973
-"Fort Rox","Utter Darkness","Crescent","-","4.89%","Wealthy Werewarrior",36973
-"Fort Rox","Utter Darkness","Crescent","-","4.87%","Nightmancer",36973
-"Fort Rox","Utter Darkness","Crescent","-","2.97%","Wereminer",36973
-"Fort Rox","Utter Darkness","Crescent","-","2.87%","Werehauler",36973
-"Fort Rox","Utter Darkness","Crescent","-","1.93%","Mischievous Wereminer",36973
-"Fort Rox","Utter Darkness","Crescent","-","1.08%","Reveling Lycanthrope",36973
-"Fort Rox","Utter Darkness","Crescent","-","0.13%","Night Shift Materials Manager",36973
-"Fort Rox","Utter Darkness","Moon","-","13.93%","Night Watcher",17135
-"Fort Rox","Utter Darkness","Moon","-","12.58%","Meteorite Golem",17135
-"Fort Rox","Utter Darkness","Moon","-","11.88%","Cursed Taskmaster",17135
-"Fort Rox","Utter Darkness","Moon","-","10.99%","Hypnotized Gunslinger",17135
-"Fort Rox","Utter Darkness","Moon","-","9.00%","Meteorite Mystic",17135
-"Fort Rox","Utter Darkness","Moon","-","8.93%","Nightfire",17135
-"Fort Rox","Utter Darkness","Moon","-","6.71%","Alpha Weremouse",17135
-"Fort Rox","Utter Darkness","Moon","-","5.96%","Arcane Summoner",17135
-"Fort Rox","Utter Darkness","Moon","-","5.09%","Wealthy Werewarrior",17135
-"Fort Rox","Utter Darkness","Moon","-","4.90%","Nightmancer",17135
-"Fort Rox","Utter Darkness","Moon","-","4.89%","Wereminer",17135
-"Fort Rox","Utter Darkness","Moon","-","2.11%","Mischievous Wereminer",17135
-"Fort Rox","Utter Darkness","Moon","-","1.10%","Reveling Lycanthrope",17135
-"Fort Rox","Utter Darkness","Moon","-","0.97%","Night Shift Materials Manager",17135
-"Fort Rox","Utter Darkness","Moon","-","0.95%","Werehauler",17135
-"Fort Rox","First Light","Gouda","-","67.03%","Battering Ram",279
-"Fort Rox","First Light","Gouda","-","21.86%","Nightfire",279
-"Fort Rox","First Light","Gouda","-","2.87%","Cursed Taskmaster",279
-"Fort Rox","First Light","Gouda","-","2.51%","Night Watcher",279
-"Fort Rox","First Light","Gouda","-","2.15%","Meteorite Golem",279
-"Fort Rox","First Light","Gouda","-","2.15%","Meteorite Mystic",279
-"Fort Rox","First Light","Gouda","-","1.43%","Hypnotized Gunslinger",279
-"Fort Rox","First Light","SB+","-","33.33%","Battering Ram",108
-"Fort Rox","First Light","SB+","-","27.78%","Nightfire",108
-"Fort Rox","First Light","SB+","-","12.04%","Meteorite Mystic",108
-"Fort Rox","First Light","SB+","-","9.26%","Night Watcher",108
-"Fort Rox","First Light","SB+","-","7.41%","Meteorite Golem",108
-"Fort Rox","First Light","SB+","-","4.63%","Cursed Taskmaster",108
-"Fort Rox","First Light","SB+","-","3.70%","Arcane Summoner",108
-"Fort Rox","First Light","SB+","-","1.85%","Hypnotized Gunslinger",108
-"Fort Rox","First Light","Crescent","-","24.45%","Nightfire",40341
-"Fort Rox","First Light","Crescent","-","14.82%","Cursed Taskmaster",40341
-"Fort Rox","First Light","Crescent","-","14.79%","Meteorite Golem",40341
-"Fort Rox","First Light","Crescent","-","14.70%","Night Watcher",40341
-"Fort Rox","First Light","Crescent","-","12.01%","Hypnotized Gunslinger",40341
-"Fort Rox","First Light","Crescent","-","10.05%","Meteorite Mystic",40341
-"Fort Rox","First Light","Crescent","-","9.18%","Arcane Summoner",40341
-"Fort Rox","First Light","Moon","-","23.83%","Cursed Taskmaster",21819
-"Fort Rox","First Light","Moon","-","22.11%","Nightfire",21819
-"Fort Rox","First Light","Moon","-","12.98%","Night Watcher",21819
-"Fort Rox","First Light","Moon","-","11.85%","Arcane Summoner",21819
-"Fort Rox","First Light","Moon","-","10.07%","Meteorite Golem",21819
-"Fort Rox","First Light","Moon","-","9.68%","Meteorite Mystic",21819
-"Fort Rox","First Light","Moon","-","9.47%","Hypnotized Gunslinger",21819
-"Fort Rox","Dawn","Gouda","-","36.27%","Monster of the Meteor",1398
-"Fort Rox","Dawn","Gouda","-","31.90%","Dawn Guardian",1398
-"Fort Rox","Dawn","Gouda","-","31.83%","Battering Ram",1398
-"Fort Rox","Dawn","SB+","-","41.27%","Dawn Guardian",676
-"Fort Rox","Dawn","SB+","-","38.61%","Monster of the Meteor",676
-"Fort Rox","Dawn","SB+","-","20.12%","Battering Ram",676
-"Fort Rox","Dawn","Crescent","-","51.20%","Dawn Guardian",30910
-"Fort Rox","Dawn","Crescent","-","48.80%","Monster of the Meteor",30910
-"Fort Rox","Dawn","Moon","-","51.11%","Dawn Guardian",38471
-"Fort Rox","Dawn","Moon","-","48.89%","Monster of the Meteor",38471
+"Fort Rox","Day","Gouda","-","29.80%","Mischievous Meteorite Miner",168157
+"Fort Rox","Day","Gouda","-","29.77%","Meteorite Miner",168157
+"Fort Rox","Day","Gouda","-","17.60%","Hardworking Hauler",168157
+"Fort Rox","Day","Gouda","-","11.89%","Meteorite Snacker",168157
+"Fort Rox","Day","Gouda","-","5.97%","Meteorite Mover",168157
+"Fort Rox","Day","Gouda","-","4.99%","Mining Materials Manager",168157
+"Fort Rox","Day","Brie","-","29.82%","Mischievous Meteorite Miner",28874
+"Fort Rox","Day","Brie","-","29.38%","Meteorite Miner",28874
+"Fort Rox","Day","Brie","-","18.09%","Hardworking Hauler",28874
+"Fort Rox","Day","Brie","-","11.96%","Meteorite Snacker",28874
+"Fort Rox","Day","Brie","-","5.93%","Meteorite Mover",28874
+"Fort Rox","Day","Brie","-","4.82%","Mining Materials Manager",28874
+"Fort Rox","Day","SB+","-","24.68%","Meteorite Miner",9251
+"Fort Rox","Day","SB+","-","23.63%","Mischievous Meteorite Miner",9251
+"Fort Rox","Day","SB+","-","17.78%","Hardworking Hauler",9251
+"Fort Rox","Day","SB+","-","15.98%","Mining Materials Manager",9251
+"Fort Rox","Day","SB+","-","15.39%","Meteorite Snacker",9251
+"Fort Rox","Day","SB+","-","2.54%","Meteorite Mover",9251
+"Fort Rox","Day","Crescent","-","25.30%","Meteorite Miner",5664
+"Fort Rox","Day","Crescent","-","25.05%","Mischievous Meteorite Miner",5664
+"Fort Rox","Day","Crescent","-","19.62%","Meteorite Snacker",5664
+"Fort Rox","Day","Crescent","-","15.40%","Hardworking Hauler",5664
+"Fort Rox","Day","Crescent","-","10.63%","Meteorite Mover",5664
+"Fort Rox","Day","Crescent","-","4.01%","Mining Materials Manager",5664
+"Fort Rox","Day","Moon","-","32.84%","Meteorite Snacker",3213
+"Fort Rox","Day","Moon","-","22.47%","Mischievous Meteorite Miner",3213
+"Fort Rox","Day","Moon","-","20.70%","Meteorite Miner",3213
+"Fort Rox","Day","Moon","-","10.83%","Meteorite Mover",3213
+"Fort Rox","Day","Moon","-","8.34%","Hardworking Hauler",3213
+"Fort Rox","Day","Moon","-","4.82%","Mining Materials Manager",3213
+"Fort Rox","Twilight","Gouda","-","28.45%","Battering Ram",3751
+"Fort Rox","Twilight","Gouda","-","17.30%","Werehauler",3751
+"Fort Rox","Twilight","Gouda","-","14.64%","Mischievous Wereminer",3751
+"Fort Rox","Twilight","Gouda","-","13.06%","Reveling Lycanthrope",3751
+"Fort Rox","Twilight","Gouda","-","11.86%","Nightmancer",3751
+"Fort Rox","Twilight","Gouda","-","8.64%","Wereminer",3751
+"Fort Rox","Twilight","Gouda","-","6.05%","Alpha Weremouse",3751
+"Fort Rox","Twilight","Brie","-","25.88%","Battering Ram",170
+"Fort Rox","Twilight","Brie","-","17.06%","Nightmancer",170
+"Fort Rox","Twilight","Brie","-","14.71%","Mischievous Wereminer",170
+"Fort Rox","Twilight","Brie","-","14.12%","Werehauler",170
+"Fort Rox","Twilight","Brie","-","10.59%","Reveling Lycanthrope",170
+"Fort Rox","Twilight","Brie","-","10.00%","Wereminer",170
+"Fort Rox","Twilight","Brie","-","7.65%","Alpha Weremouse",170
+"Fort Rox","Twilight","SB+","-","17.91%","Battering Ram",642
+"Fort Rox","Twilight","SB+","-","16.36%","Mischievous Wereminer",642
+"Fort Rox","Twilight","SB+","-","16.20%","Werehauler",642
+"Fort Rox","Twilight","SB+","-","12.77%","Nightmancer",642
+"Fort Rox","Twilight","SB+","-","12.31%","Alpha Weremouse",642
+"Fort Rox","Twilight","SB+","-","11.37%","Reveling Lycanthrope",642
+"Fort Rox","Twilight","SB+","-","9.19%","Wereminer",642
+"Fort Rox","Twilight","SB+","-","3.89%","Night Shift Materials Manager",642
+"Fort Rox","Twilight","Crescent","-","22.85%","Werehauler",106079
+"Fort Rox","Twilight","Crescent","-","18.94%","Alpha Weremouse",106079
+"Fort Rox","Twilight","Crescent","-","15.65%","Reveling Lycanthrope",106079
+"Fort Rox","Twilight","Crescent","-","14.80%","Wereminer",106079
+"Fort Rox","Twilight","Crescent","-","14.74%","Mischievous Wereminer",106079
+"Fort Rox","Twilight","Crescent","-","7.90%","Night Shift Materials Manager",106079
+"Fort Rox","Twilight","Crescent","-","5.10%","Nightmancer",106079
+"Fort Rox","Twilight","Moon","-","20.37%","Mischievous Wereminer",27984
+"Fort Rox","Twilight","Moon","-","18.75%","Alpha Weremouse",27984
+"Fort Rox","Twilight","Moon","-","16.53%","Werehauler",27984
+"Fort Rox","Twilight","Moon","-","15.96%","Wereminer",27984
+"Fort Rox","Twilight","Moon","-","13.75%","Reveling Lycanthrope",27984
+"Fort Rox","Twilight","Moon","-","9.80%","Night Shift Materials Manager",27984
+"Fort Rox","Twilight","Moon","-","4.85%","Nightmancer",27984
+"Fort Rox","Midnight","Gouda","-","26.44%","Battering Ram",764
+"Fort Rox","Midnight","Gouda","-","15.31%","Werehauler",764
+"Fort Rox","Midnight","Gouda","-","14.92%","Nightmancer",764
+"Fort Rox","Midnight","Gouda","-","9.69%","Alpha Weremouse",764
+"Fort Rox","Midnight","Gouda","-","7.85%","Mischievous Wereminer",764
+"Fort Rox","Midnight","Gouda","-","5.76%","Hypnotized Gunslinger",764
+"Fort Rox","Midnight","Gouda","-","5.24%","Night Watcher",764
+"Fort Rox","Midnight","Gouda","-","4.45%","Meteorite Golem",764
+"Fort Rox","Midnight","Gouda","-","3.53%","Wereminer",764
+"Fort Rox","Midnight","Gouda","-","2.88%","Arcane Summoner",764
+"Fort Rox","Midnight","Gouda","-","2.23%","Wealthy Werewarrior",764
+"Fort Rox","Midnight","Gouda","-","1.70%","Reveling Lycanthrope",764
+"Fort Rox","Midnight","SB+","-","16.30%","Battering Ram",184
+"Fort Rox","Midnight","SB+","-","15.22%","Nightmancer",184
+"Fort Rox","Midnight","SB+","-","13.04%","Werehauler",184
+"Fort Rox","Midnight","SB+","-","11.96%","Alpha Weremouse",184
+"Fort Rox","Midnight","SB+","-","8.15%","Hypnotized Gunslinger",184
+"Fort Rox","Midnight","SB+","-","6.52%","Night Shift Materials Manager",184
+"Fort Rox","Midnight","SB+","-","5.98%","Mischievous Wereminer",184
+"Fort Rox","Midnight","SB+","-","5.98%","Night Watcher",184
+"Fort Rox","Midnight","SB+","-","4.89%","Wereminer",184
+"Fort Rox","Midnight","SB+","-","3.80%","Reveling Lycanthrope",184
+"Fort Rox","Midnight","SB+","-","3.80%","Arcane Summoner",184
+"Fort Rox","Midnight","SB+","-","3.26%","Meteorite Golem",184
+"Fort Rox","Midnight","SB+","-","1.09%","Wealthy Werewarrior",184
+"Fort Rox","Midnight","Crescent","-","13.76%","Alpha Weremouse",60750
+"Fort Rox","Midnight","Crescent","-","13.04%","Werehauler",60750
+"Fort Rox","Midnight","Crescent","-","11.76%","Nightmancer",60750
+"Fort Rox","Midnight","Crescent","-","9.98%","Wealthy Werewarrior",60750
+"Fort Rox","Midnight","Crescent","-","9.92%","Mischievous Wereminer",60750
+"Fort Rox","Midnight","Crescent","-","9.04%","Wereminer",60750
+"Fort Rox","Midnight","Crescent","-","7.80%","Night Shift Materials Manager",60750
+"Fort Rox","Midnight","Crescent","-","6.01%","Hypnotized Gunslinger",60750
+"Fort Rox","Midnight","Crescent","-","5.19%","Reveling Lycanthrope",60750
+"Fort Rox","Midnight","Crescent","-","4.81%","Night Watcher",60750
+"Fort Rox","Midnight","Crescent","-","4.77%","Arcane Summoner",60750
+"Fort Rox","Midnight","Crescent","-","3.92%","Meteorite Golem",60750
+"Fort Rox","Midnight","Moon","-","18.51%","Alpha Weremouse",19270
+"Fort Rox","Midnight","Moon","-","10.99%","Mischievous Wereminer",19270
+"Fort Rox","Midnight","Moon","-","10.11%","Night Shift Materials Manager",19270
+"Fort Rox","Midnight","Moon","-","9.97%","Wereminer",19270
+"Fort Rox","Midnight","Moon","-","9.94%","Nightmancer",19270
+"Fort Rox","Midnight","Moon","-","9.60%","Wealthy Werewarrior",19270
+"Fort Rox","Midnight","Moon","-","6.27%","Werehauler",19270
+"Fort Rox","Midnight","Moon","-","5.22%","Reveling Lycanthrope",19270
+"Fort Rox","Midnight","Moon","-","5.08%","Hypnotized Gunslinger",19270
+"Fort Rox","Midnight","Moon","-","4.92%","Arcane Summoner",19270
+"Fort Rox","Midnight","Moon","-","4.80%","Night Watcher",19270
+"Fort Rox","Midnight","Moon","-","4.60%","Meteorite Golem",19270
+"Fort Rox","Pitch","Gouda","-","40.37%","Battering Ram",218
+"Fort Rox","Pitch","Gouda","-","10.55%","Hypnotized Gunslinger",218
+"Fort Rox","Pitch","Gouda","-","10.09%","Nightfire",218
+"Fort Rox","Pitch","Gouda","-","9.63%","Nightmancer",218
+"Fort Rox","Pitch","Gouda","-","5.96%","Meteorite Mystic",218
+"Fort Rox","Pitch","Gouda","-","5.96%","Night Watcher",218
+"Fort Rox","Pitch","Gouda","-","4.59%","Cursed Taskmaster",218
+"Fort Rox","Pitch","Gouda","-","3.21%","Arcane Summoner",218
+"Fort Rox","Pitch","Gouda","-","3.21%","Meteorite Golem",218
+"Fort Rox","Pitch","Gouda","-","2.29%","Alpha Weremouse",218
+"Fort Rox","Pitch","Gouda","-","1.38%","Mischievous Wereminer",218
+"Fort Rox","Pitch","Gouda","-","0.92%","Wereminer",218
+"Fort Rox","Pitch","Gouda","-","0.92%","Wealthy Werewarrior",218
+"Fort Rox","Pitch","Gouda","-","0.46%","Werehauler",218
+"Fort Rox","Pitch","Gouda","-","0.46%","Reveling Lycanthrope",218
+"Fort Rox","Pitch","Crescent","-","14.51%","Hypnotized Gunslinger",19552
+"Fort Rox","Pitch","Crescent","-","10.47%","Nightmancer",19552
+"Fort Rox","Pitch","Crescent","-","9.79%","Wealthy Werewarrior",19552
+"Fort Rox","Pitch","Crescent","-","9.16%","Nightfire",19552
+"Fort Rox","Pitch","Crescent","-","7.73%","Night Shift Materials Manager",19552
+"Fort Rox","Pitch","Crescent","-","6.89%","Meteorite Golem",19552
+"Fort Rox","Pitch","Crescent","-","6.17%","Alpha Weremouse",19552
+"Fort Rox","Pitch","Crescent","-","5.15%","Werehauler",19552
+"Fort Rox","Pitch","Crescent","-","5.08%","Wereminer",19552
+"Fort Rox","Pitch","Crescent","-","5.07%","Night Watcher",19552
+"Fort Rox","Pitch","Crescent","-","4.96%","Arcane Summoner",19552
+"Fort Rox","Pitch","Crescent","-","4.80%","Cursed Taskmaster",19552
+"Fort Rox","Pitch","Crescent","-","4.01%","Reveling Lycanthrope",19552
+"Fort Rox","Pitch","Crescent","-","3.14%","Mischievous Wereminer",19552
+"Fort Rox","Pitch","Crescent","-","3.07%","Meteorite Mystic",19552
+"Fort Rox","Pitch","Moon","-","15.04%","Hypnotized Gunslinger",7921
+"Fort Rox","Pitch","Moon","-","10.79%","Night Shift Materials Manager",7921
+"Fort Rox","Pitch","Moon","-","10.48%","Wealthy Werewarrior",7921
+"Fort Rox","Pitch","Moon","-","9.46%","Nightmancer",7921
+"Fort Rox","Pitch","Moon","-","7.18%","Meteorite Golem",7921
+"Fort Rox","Pitch","Moon","-","6.50%","Alpha Weremouse",7921
+"Fort Rox","Pitch","Moon","-","5.58%","Wereminer",7921
+"Fort Rox","Pitch","Moon","-","5.50%","Night Watcher",7921
+"Fort Rox","Pitch","Moon","-","5.00%","Arcane Summoner",7921
+"Fort Rox","Pitch","Moon","-","4.94%","Meteorite Mystic",7921
+"Fort Rox","Pitch","Moon","-","4.92%","Cursed Taskmaster",7921
+"Fort Rox","Pitch","Moon","-","4.68%","Nightfire",7921
+"Fort Rox","Pitch","Moon","-","3.81%","Reveling Lycanthrope",7921
+"Fort Rox","Pitch","Moon","-","3.26%","Mischievous Wereminer",7921
+"Fort Rox","Pitch","Moon","-","2.85%","Werehauler",7921
+"Fort Rox","Utter Darkness","Gouda","-","67.05%","Battering Ram",437
+"Fort Rox","Utter Darkness","Gouda","-","11.44%","Nightfire",437
+"Fort Rox","Utter Darkness","Gouda","-","4.35%","Nightmancer",437
+"Fort Rox","Utter Darkness","Gouda","-","2.97%","Cursed Taskmaster",437
+"Fort Rox","Utter Darkness","Gouda","-","2.75%","Meteorite Mystic",437
+"Fort Rox","Utter Darkness","Gouda","-","2.29%","Hypnotized Gunslinger",437
+"Fort Rox","Utter Darkness","Gouda","-","2.06%","Meteorite Golem",437
+"Fort Rox","Utter Darkness","Gouda","-","2.06%","Alpha Weremouse",437
+"Fort Rox","Utter Darkness","Gouda","-","1.83%","Night Watcher",437
+"Fort Rox","Utter Darkness","Gouda","-","1.37%","Wereminer",437
+"Fort Rox","Utter Darkness","Gouda","-","1.14%","Reveling Lycanthrope",437
+"Fort Rox","Utter Darkness","Gouda","-","0.23%","Arcane Summoner",437
+"Fort Rox","Utter Darkness","Gouda","-","0.23%","Wealthy Werewarrior",437
+"Fort Rox","Utter Darkness","Gouda","-","0.23%","Mischievous Wereminer",437
+"Fort Rox","Utter Darkness","Crescent","-","14.91%","Hypnotized Gunslinger",37557
+"Fort Rox","Utter Darkness","Crescent","-","12.11%","Nightfire",37557
+"Fort Rox","Utter Darkness","Crescent","-","12.02%","Meteorite Golem",37557
+"Fort Rox","Utter Darkness","Crescent","-","11.82%","Cursed Taskmaster",37557
+"Fort Rox","Utter Darkness","Crescent","-","9.90%","Night Watcher",37557
+"Fort Rox","Utter Darkness","Crescent","-","7.75%","Meteorite Mystic",37557
+"Fort Rox","Utter Darkness","Crescent","-","6.91%","Alpha Weremouse",37557
+"Fort Rox","Utter Darkness","Crescent","-","5.84%","Arcane Summoner",37557
+"Fort Rox","Utter Darkness","Crescent","-","4.89%","Wealthy Werewarrior",37557
+"Fort Rox","Utter Darkness","Crescent","-","4.88%","Nightmancer",37557
+"Fort Rox","Utter Darkness","Crescent","-","2.96%","Wereminer",37557
+"Fort Rox","Utter Darkness","Crescent","-","2.87%","Werehauler",37557
+"Fort Rox","Utter Darkness","Crescent","-","1.93%","Mischievous Wereminer",37557
+"Fort Rox","Utter Darkness","Crescent","-","1.09%","Reveling Lycanthrope",37557
+"Fort Rox","Utter Darkness","Crescent","-","0.13%","Night Shift Materials Manager",37557
+"Fort Rox","Utter Darkness","Moon","-","13.88%","Night Watcher",17525
+"Fort Rox","Utter Darkness","Moon","-","12.58%","Meteorite Golem",17525
+"Fort Rox","Utter Darkness","Moon","-","11.89%","Cursed Taskmaster",17525
+"Fort Rox","Utter Darkness","Moon","-","10.94%","Hypnotized Gunslinger",17525
+"Fort Rox","Utter Darkness","Moon","-","8.99%","Meteorite Mystic",17525
+"Fort Rox","Utter Darkness","Moon","-","8.88%","Nightfire",17525
+"Fort Rox","Utter Darkness","Moon","-","6.75%","Alpha Weremouse",17525
+"Fort Rox","Utter Darkness","Moon","-","6.05%","Arcane Summoner",17525
+"Fort Rox","Utter Darkness","Moon","-","5.08%","Wealthy Werewarrior",17525
+"Fort Rox","Utter Darkness","Moon","-","4.92%","Nightmancer",17525
+"Fort Rox","Utter Darkness","Moon","-","4.85%","Wereminer",17525
+"Fort Rox","Utter Darkness","Moon","-","2.09%","Mischievous Wereminer",17525
+"Fort Rox","Utter Darkness","Moon","-","1.11%","Reveling Lycanthrope",17525
+"Fort Rox","Utter Darkness","Moon","-","1.03%","Night Shift Materials Manager",17525
+"Fort Rox","Utter Darkness","Moon","-","0.96%","Werehauler",17525
+"Fort Rox","First Light","Gouda","-","66.43%","Battering Ram",283
+"Fort Rox","First Light","Gouda","-","22.26%","Nightfire",283
+"Fort Rox","First Light","Gouda","-","2.83%","Night Watcher",283
+"Fort Rox","First Light","Gouda","-","2.83%","Cursed Taskmaster",283
+"Fort Rox","First Light","Gouda","-","2.12%","Meteorite Golem",283
+"Fort Rox","First Light","Gouda","-","2.12%","Meteorite Mystic",283
+"Fort Rox","First Light","Gouda","-","1.41%","Hypnotized Gunslinger",283
+"Fort Rox","First Light","SB+","-","33.94%","Battering Ram",109
+"Fort Rox","First Light","SB+","-","27.52%","Nightfire",109
+"Fort Rox","First Light","SB+","-","11.93%","Meteorite Mystic",109
+"Fort Rox","First Light","SB+","-","9.17%","Night Watcher",109
+"Fort Rox","First Light","SB+","-","7.34%","Meteorite Golem",109
+"Fort Rox","First Light","SB+","-","4.59%","Cursed Taskmaster",109
+"Fort Rox","First Light","SB+","-","3.67%","Arcane Summoner",109
+"Fort Rox","First Light","SB+","-","1.83%","Hypnotized Gunslinger",109
+"Fort Rox","First Light","Crescent","-","24.41%","Nightfire",41057
+"Fort Rox","First Light","Crescent","-","14.83%","Cursed Taskmaster",41057
+"Fort Rox","First Light","Crescent","-","14.79%","Meteorite Golem",41057
+"Fort Rox","First Light","Crescent","-","14.72%","Night Watcher",41057
+"Fort Rox","First Light","Crescent","-","12.05%","Hypnotized Gunslinger",41057
+"Fort Rox","First Light","Crescent","-","10.05%","Meteorite Mystic",41057
+"Fort Rox","First Light","Crescent","-","9.15%","Arcane Summoner",41057
+"Fort Rox","First Light","Moon","-","23.87%","Cursed Taskmaster",22293
+"Fort Rox","First Light","Moon","-","22.11%","Nightfire",22293
+"Fort Rox","First Light","Moon","-","12.91%","Night Watcher",22293
+"Fort Rox","First Light","Moon","-","11.82%","Arcane Summoner",22293
+"Fort Rox","First Light","Moon","-","10.02%","Meteorite Golem",22293
+"Fort Rox","First Light","Moon","-","9.76%","Meteorite Mystic",22293
+"Fort Rox","First Light","Moon","-","9.51%","Hypnotized Gunslinger",22293
+"Fort Rox","Dawn","Gouda","-","36.18%","Monster of the Meteor",1462
+"Fort Rox","Dawn","Gouda","-","32.15%","Dawn Guardian",1462
+"Fort Rox","Dawn","Gouda","-","31.67%","Battering Ram",1462
+"Fort Rox","Dawn","SB+","-","40.92%","Dawn Guardian",716
+"Fort Rox","Dawn","SB+","-","38.97%","Monster of the Meteor",716
+"Fort Rox","Dawn","SB+","-","20.11%","Battering Ram",716
+"Fort Rox","Dawn","Crescent","-","51.22%","Dawn Guardian",31648
+"Fort Rox","Dawn","Crescent","-","48.78%","Monster of the Meteor",31648
+"Fort Rox","Dawn","Moon","-","50.98%","Dawn Guardian",39407
+"Fort Rox","Dawn","Moon","-","49.02%","Monster of the Meteor",39407
+"Fort Rox","Heart of the Meteor","Sunrise","-","100.00%","Heart of the Meteor",1487

--- a/data/pop-js/fort-rox.js
+++ b/data/pop-js/fort-rox.js
@@ -15,9 +15,8 @@ module.exports = {
   },
   series: [
     { // day
+      stage: utils.genVarField('stage', 'Day'),
       config: [ {
-        vars: { stage: { Day: true } },
-        fields: { stage: 'Day' },
         opts: {
           include: [
             'Hardworking Hauler',
@@ -31,9 +30,8 @@ module.exports = {
       } ]
     },
     { // twilight
+      stage: utils.genVarField('stage', 'Twilight'),
       config: [ {
-        vars: { stage: { Twilight: true } },
-        fields: { stage: 'Twilight' },
         opts: {
           include: [
             'Alpha Weremouse',
@@ -49,9 +47,8 @@ module.exports = {
       } ]
     },
     { // Midnight
+      stage: utils.genVarField('stage', 'Midnight'),
       config: [ {
-        vars: { stage: { Midnight: true } },
-        fields: { stage: 'Midnight' },
         opts: {
           include: [
             'Alpha Weremouse',
@@ -72,9 +69,8 @@ module.exports = {
       } ]
     },
     { // Pitch
+      stage: utils.genVarField('stage', 'Pitch'),
       config: [ {
-        vars: { stage: { Pitch: true } },
-        fields: { stage: 'Pitch' },
         opts: {
           include: [
             'Alpha Weremouse',
@@ -98,9 +94,8 @@ module.exports = {
       } ]
     },
     { // Utter Darkness
+      stage: utils.genVarField('stage', 'Utter Darkness'),
       config: [ {
-        vars: { stage: { 'Utter Darkness': true } },
-        fields: { stage: 'Utter Darkness' },
         opts: {
           include: [
             'Alpha Weremouse',
@@ -124,9 +119,8 @@ module.exports = {
       } ]
     },
     { // First Light
+      stage: utils.genVarField('stage', 'First Light'),
       config: [ {
-        vars: { stage: { 'First Light': true } },
-        fields: { stage: 'First Light' },
         opts: {
           include: [
             'Arcane Summoner',
@@ -142,14 +136,24 @@ module.exports = {
       } ]
     },
     { // Dawn
+      stage: utils.genVarField('stage', 'Dawn'),
       config: [ {
-        vars: { stage: { 'Dawn': true } },
-        fields: { stage: 'Dawn' },
         opts: {
           include: [
             'Battering Ram',
             'Dawn Guardian',
             'Monster of the Meteor'
+          ]
+        }
+      } ]
+    },
+    { // Heart of the Meteor
+      stage: utils.genVarField('stage', 'Heart of the Meteor'),
+      cheese: utils.genVarField('cheese', 'Sunrise'),
+      config: [ {
+        opts: {
+          include: [
+            'Heart of the Meteor'
           ]
         }
       } ]

--- a/src/bookmarklet/bm-cre.js
+++ b/src/bookmarklet/bm-cre.js
@@ -94,8 +94,8 @@
           stage_five: "First Light"
         };
         return stages[stage];
-      } else if (tmpPhase === "lair") {
-        return "Portal";
+      } else if (fortRoxQuest["is_lair"]) {
+        return "Heart of the Meteor";
       } else {
         return tmpPhase;
       }

--- a/src/bookmarklet/bm-setup-fields.js
+++ b/src/bookmarklet/bm-setup-fields.js
@@ -84,8 +84,8 @@
           stage_five: "First Light"
         };
         return stages[stage];
-      } else if (tmpPhase === "lair") {
-        return "Portal";
+    } else if (fortRoxQuest["is_lair"]) {
+        return "Heart of the Meteor";
       } else {
         return tmpPhase;
       }


### PR DESCRIPTION
The previous population mega-update accidentally removed HoTM from Fort Rox.

This was due to the Fort Rox script not properly having the stage properly set up to gather the data, meaning that HoTM was hand-jammed into the fort-fox.csv.
