### PR TITLE
Fort Rox: correct overall minluck

### DIFF
--- a/src/main/cre.js
+++ b/src/main/cre.js
@@ -303,6 +303,14 @@ function showPop(type) {
           mousePower /= 2;
         }
 
+        if (
+          ((mouseName === "Nightmancer" && fortRox.ballistaLevel >= 3) ||
+           (mouseName === "Nightfire" && fortRox.cannonLevel >= 3)
+          ) &&
+          (eff > 0)) {
+          mousePower = 0;
+        }
+
         var catchRate = calcCR(eff, trapPower, trapLuck, mousePower);
         catchRate = calcCREffects(catchRate, mouseName, eff, mousePower);
         catchRate = calcCRMods(catchRate, mouseName);


### PR DESCRIPTION
A slightly hacky solution, but similar to the already existing one for the other mice based on upgrades.
Updates MP to 0 for Nightmancer and Nightfire if the relevant upgrade is level 3.
Addresses issue https://github.com/tsitu/MH-Tools/issues/172