### PR TITLE
Removed Sylvan Mouse from Jungle of Dread population

### DIFF
--- a/data/populations.csv
+++ b/data/populations.csv
@@ -1794,9 +1794,7 @@ Jungle of Dread,-,Magical Havarti,-,100.00%,Stonework Warrior,
 Jungle of Dread,-,SB+,-,90.35%,Swarm of Pygmy Mice,26438
 Jungle of Dread,-,SB+,-,9.65%,Pygmy Wrangler,
 Jungle of Dread,-,Gouda,-,87.20%,Swarm of Pygmy Mice,52515
-Jungle of Dread,-,Gouda,-,9.86%,Sylvan,
 Jungle of Dread,-,Gouda,-,2.95%,Pygmy Wrangler,
-Jungle of Dread,-,Brie,-,93.33%,Sylvan,1694
 Jungle of Dread,-,Brie,-,6.67%,Swarm of Pygmy Mice,
 King's Arms,-,Gilded,-,24.95%,Burglar,5715
 King's Arms,-,Gilded,-,10.60%,Dwarf,


### PR DESCRIPTION
Removed Sylvan from Jungle of Dread population as per January 17, 2023 update:
https://www.mousehuntgame.com/newspost.php?news_post_id=723