### PR TITLE
Load site bookmarklets from jsdelivr instead of relative URLs

### DIFF
--- a/src/utils/bookmarklets.js
+++ b/src/utils/bookmarklets.js
@@ -27,7 +27,7 @@ function makeBookmarkletString(content) {
  */
 function loadBookmarkletFromJS(url, storageKey, linkSelector) {
   $.get(
-    url,
+    `https://cdn.jsdelivr.net/gh/tsitu/MH-Tools@master/${url}`,
     function(data) {
       checkBookmarklet(makeBookmarkletString(data), storageKey);
     },


### PR DESCRIPTION
Forgot to have the website load bookmarklets from lastest jsdelivr instead of relative URLs (they are some local but they are not minimized).