### PR TITLE
Update Marketplace Analyzer

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+# This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: ${{ github.ref }}
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
- Refactor marketplace analyzer to work with new API

The Analyzer bookmarklet needed a significant rewrite due to the changes in the marketplace API. The first hurdle is that you don't know how many records you are able to retrieve; you just "Load More" until that api gives you back less than 10 items or an empty array, then you know you're at the end.

Positive of the new API, it returns an absolute id of your listings. Storing those ids, we can tell if we've fetched that page of history if any of the ids exist in storage. That way, if you were to come back to the bookmarlet and hit fetch, it would only fetch until it encounters a previously stored listing.

Possible future issues: each completed listing we put in local storage is about 300 Bytes. Major browsers limit it to 10MB which will give room for just under 35,000 listings.

