### PR TITLE
Update build sample size URLs

### DIFF
--- a/build/process-sample-size.js
+++ b/build/process-sample-size.js
@@ -19,11 +19,11 @@ const puppeteer = require("puppeteer");
 
 // GitHub-served raw JSON file URLs from gh-pages branch
 const overallURL =
-  "https://raw.githubusercontent.com/tsitu/MH-Tools/gh-pages/data/json/sample-summary-overall.json";
+  "https://tsitu.github.io/MH-Tools/data/json/sample-summary-overall.json";
 const conciseURL =
-  "https://raw.githubusercontent.com/tsitu/MH-Tools/gh-pages/data/json/sample-summary-concise.json";
+  "https://tsitu.github.io/MH-Tools/data/json/sample-summary-concise.json";
 const detailedURL =
-  "https://raw.githubusercontent.com/tsitu/MH-Tools/gh-pages/data/json/sample-summary-detailed.json";
+  "https://tsitu.github.io/MH-Tools/data/json/sample-summary-detailed.json";
 
 /**
  * Returns ideal sample size for 10% relative uncertainty at 95% level


### PR DESCRIPTION
Missed some URLs that point to the old gh-pages branch. These are used in the build.