### PR TITLE
Fix FI sublocation logic

### DIFF
--- a/src/bookmarklet/bm-cre.js
+++ b/src/bookmarklet/bm-cre.js
@@ -412,25 +412,17 @@
       var fi = userQuests["QuestFloatingIslands"]["hunting_site_atts"];
       var fiStage = fi["island_name"];
 
-      if (fi["enemy"]) {
-        if (
-          fi["enemy"]["name"].indexOf("Warden") >= 0 ||
-          fi["enemy"]["name"].indexOf("Paragon") >= 0 ||
-          fi["enemy"]["name"].indexOf("Empress") >= 0
-        ) {
-          if (fi["is_enemy_encounter"]) {
-            if (fi["is_low_tier_island"]) {
-              return "Sky Wardens";
-            } else if (fi["is_high_tier_island"]) {
-              return "Sky Paragons";
-            } else if (fi["is_vault_island"]) {
-              return "Empress";
-            }
-          }
+      if (fi["is_enemy_encounter"]) {
+        if (fi["is_low_tier_island"]) {
+          return "Sky Wardens";
+        } else if (fi["is_high_tier_island"]) {
+          return "Sky Paragons";
+        } else if (fi["is_vault_island"]) {
+          return "Empress";
         }
       } else if (userCheese === "Sky Pirate Swiss Cheese") {
         const piratesNum = fi["activated_island_mod_types"].filter(t => t === "sky_pirates").length;
-        return (fi["is_vault_island"] ? "Vault " : "Island ") + piratesNum === 0 ? "No Pirates" : "Pirates x" + piratesNum;
+        return `${fi["is_vault_island"] ? "Vault " : "Island "}${piratesNum === 0 ? "No Pirates" : "Pirates x" + piratesNum}`;
       } else if ((userCheese === "Cloud Cheesecake" || userCheese === "Extra Rich Cloud Cheesecake") &&
                   fi["activated_island_mod_types"].filter(i => i === "loot_cache").length >= 2) {
         fiStage += ` - Loot x${fi["activated_island_mod_types"].filter(i => i === "loot_cache").length}`

--- a/src/bookmarklet/bm-setup-fields.js
+++ b/src/bookmarklet/bm-setup-fields.js
@@ -400,12 +400,6 @@
       var fi = userQuests["QuestFloatingIslands"]["hunting_site_atts"];
       var fiStage = fi["island_name"];
 
-      if (fi["enemy"]) {
-        if (
-          fi["enemy"]["name"].indexOf("Warden") >= 0 ||
-          fi["enemy"]["name"].indexOf("Paragon") >= 0 ||
-          fi["enemy"]["name"].indexOf("Empress") >= 0
-        ) {
           if (fi["is_enemy_encounter"]) {
             if (fi["is_low_tier_island"]) {
               return "Sky Wardens";
@@ -414,11 +408,9 @@
             } else if (fi["is_vault_island"]) {
               return "Empress";
             }
-          }
-        }
       } else if (userCheese === "Sky Pirate Swiss Cheese") {
         const piratesNum = fi["activated_island_mod_types"].filter(t => t === "sky_pirates").length;
-        return (fi["is_vault_island"] ? "Vault " : "Island ") + piratesNum === 0 ? "No Pirates" : "Pirates x" + piratesNum;
+        return `${fi["is_vault_island"] ? "Vault " : "Island "}${piratesNum === 0 ? "No Pirates" : "Pirates x" + piratesNum}`;
       } else if ((userCheese === "Cloud Cheesecake" || userCheese === "Extra Rich Cloud Cheesecake") &&
                   fi["activated_island_mod_types"].filter(i => i === "loot_cache").length >= 2) {
         fiStage += ` - Loot x${fi["activated_island_mod_types"].filter(i => i === "loot_cache").length}`

--- a/src/bookmarklet/bm-setup-fields.js
+++ b/src/bookmarklet/bm-setup-fields.js
@@ -400,14 +400,14 @@
       var fi = userQuests["QuestFloatingIslands"]["hunting_site_atts"];
       var fiStage = fi["island_name"];
 
-          if (fi["is_enemy_encounter"]) {
-            if (fi["is_low_tier_island"]) {
-              return "Sky Wardens";
-            } else if (fi["is_high_tier_island"]) {
-              return "Sky Paragons";
-            } else if (fi["is_vault_island"]) {
-              return "Empress";
-            }
+      if (fi["is_enemy_encounter"]) {
+        if (fi["is_low_tier_island"]) {
+          return "Sky Wardens";
+        } else if (fi["is_high_tier_island"]) {
+          return "Sky Paragons";
+        } else if (fi["is_vault_island"]) {
+          return "Empress";
+        }
       } else if (userCheese === "Sky Pirate Swiss Cheese") {
         const piratesNum = fi["activated_island_mod_types"].filter(t => t === "sky_pirates").length;
         return `${fi["is_vault_island"] ? "Vault " : "Island "}${piratesNum === 0 ? "No Pirates" : "Pirates x" + piratesNum}`;
@@ -453,6 +453,19 @@
         return "Three Papyrus";
       } else if (farmState === "boss") {
         return "Boss";
+      }
+    } else if (userLocation === "Bountiful Beanstalk") {
+      const bbQuest = userQuests["QuestBountifulBeanstalk"];
+      if (bbQuest["in_castle"]) {
+        if (bbQuest["castle"]["is_boss_encounter"]) {
+          return "Castle Giants";
+        } else {
+          return bbQuest["castle"]["current_floor"]["name"].replace(" Floor", "");
+        }
+      } else {
+        return bbQuest["beanstalk"]["is_boss_encounter"]
+          ? "Beanstalk Boss"
+          : "Beanstalk"
       }
     }
 


### PR DESCRIPTION
- Resolve reported issue in FI sublocation logic
- Add BB sublocation logic to bm-setup

`fi["enemy"]` seems to be true before the boss encounter so it was always taking priority over the other `else if` branches.  
Instead use the `is_enemy_encounter` flag. There was some string funny-business going on with conditional concatenation and not producing the expected results.

Also propagated the BB sublocation logic to setup bookmarklet as it was not done in that original CRE PR.
