### PR TITLE
use regex to match cheese in best setup fields

### DIFF
--- a/src/bookmarklet/bm-setup-fields.js
+++ b/src/bookmarklet/bm-setup-fields.js
@@ -571,7 +571,7 @@
         userCheese = userCheese.slice(16, userCheese.length);
         userSublocation = userCheese;
       } else {
-        userCheese = userCheese.slice(0, userCheese.indexOf(" Cheese"));
+        userCheese = userCheese.replace(/ Cheese$/gi, '');
       }
     } else if (userCheese === "Fusion Fondue") {
       urlParams["location"] = "M400 Hunting";


### PR DESCRIPTION
use regex to match cheese to avoid matching cheesecake and properly load the cheeses in Floating Islands