### PR TITLE
Use Balack's Cove quest for stage

### DIFF
--- a/src/bookmarklet/bm-cre.js
+++ b/src/bookmarklet/bm-cre.js
@@ -54,7 +54,7 @@
     var userViewingAtts = user["viewing_atts"];
 
     if (userLocation === "Balack's Cove") {
-      var tide = userViewingAtts["tide"];
+      var tide = userQuests["QuestBalacksCove"]["tide"]["level"];
       if (tide === "low") {
         return "Low Tide";
       } else if (tide === "med") {

--- a/src/bookmarklet/bm-setup-fields.js
+++ b/src/bookmarklet/bm-setup-fields.js
@@ -44,7 +44,7 @@
     var userViewingAtts = user["viewing_atts"];
 
     if (userLocation === "Balack's Cove") {
-      var tide = userViewingAtts["tide"];
+      var tide = userQuests["QuestBalacksCove"]["tide"]["level"];
       if (tide === "low") {
         return "Low Tide";
       } else if (tide === "med") {


### PR DESCRIPTION
The viewing atts no longer contain tide for Balack's Cove. Probably removed in the 2023-01-17 patch.

Use quest object instead.